### PR TITLE
feat: persistence meter, consensus tuning, TLS fix, spammer/arch docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,6 +1099,7 @@ name = "arc-eth-engine"
 version = "0.0.1"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types",

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ QUAKE_MANIFEST ?= crates/quake/scenarios/localdev.toml
 NUM_VALIDATORS := $(shell grep -c '^\[nodes\.validator' $(QUAKE_MANIFEST) 2>/dev/null || echo 5)
 QUAKE := cargo run --bin quake --
 LOAD_PREDEFINED_ARC_REMOTE_SIGNER_KEYS := true
+DEFAULT_BRANCH ?= $(shell git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+ifeq ($(DEFAULT_BRANCH),)
+DEFAULT_BRANCH = master
+endif
 
 ##@ Help
 .PHONY: help
@@ -51,7 +55,7 @@ buf-format: ## Format protobuf files using buf
 
 .PHONY: buf-breaking
 buf-breaking: ## Check for breaking changes in protobuf files
-	buf breaking --against '.git#branch=master'
+	buf breaking --against '.git#branch=$(DEFAULT_BRANCH)'
 
 .PHONY: lint
 lint: fmt buf-format build-contract ## Run formatting and linting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Arc Node
 
-> The Economic OS for the internet
+> [!IMPORTANT]
+> Arc is currently in testnet, and this is alpha software currently undergoing audits.
+
+The Economic OS for the internet
 
 [![Website](https://img.shields.io/badge/Website-arc.network-blue)](https://www.arc.network/)
 

--- a/crates/eth-engine/Cargo.toml
+++ b/crates/eth-engine/Cargo.toml
@@ -14,6 +14,7 @@ mocks = ["dep:mockall"]
 
 # alloy crates
 alloy-consensus         = { workspace = true }
+alloy-eips              = { workspace = true }
 alloy-genesis           = { workspace = true }
 alloy-primitives        = { workspace = true }
 alloy-rpc-types         = { workspace = true }
@@ -29,7 +30,7 @@ backon = { workspace = true }
 ethereum_serde_utils = "0.8.0"
 eyre = { workspace = true }
 hex = { workspace = true }
-jsonrpsee = { workspace = true }
+jsonrpsee = { workspace = true, features = ["ws-client"] }
 jsonrpsee-types = { workspace = true }
 jsonwebtoken = { workspace = true }
 malachitebft-core-types = { workspace = true }

--- a/crates/eth-engine/src/engine.rs
+++ b/crates/eth-engine/src/engine.rs
@@ -39,6 +39,16 @@ use crate::ipc::{engine_ipc::EngineIPC, ethereum_ipc::EthereumIPC};
 use crate::json_structures::ExecutionBlock;
 use crate::rpc::{engine_rpc::EngineRpc, ethereum_rpc::EthereumRPC};
 
+/// A subscription-capable transport endpoint for the execution layer.
+///
+/// Exposed so that callers (e.g. startup replay, RPC sync) can establish
+/// auxiliary subscriptions without Engine needing to know about those concerns.
+#[derive(Clone, Debug)]
+pub enum SubscriptionEndpoint {
+    Ipc { socket_path: String },
+    Ws { url: Url },
+}
+
 #[cfg_attr(any(test, feature = "mocks"), mockall::automock)]
 #[async_trait]
 pub trait EngineAPI: Send + Sync {
@@ -105,7 +115,10 @@ impl Engine {
     pub async fn new_ipc(execution_socket: &str, eth_socket: &str) -> eyre::Result<Self> {
         let api = Box::new(EngineIPC::new(execution_socket).await?);
         let eth = Box::new(EthereumIPC::new(eth_socket).await?);
-        Ok(Self::new(api, eth))
+        let sub_endpoint = SubscriptionEndpoint::Ipc {
+            socket_path: eth_socket.to_owned(),
+        };
+        Ok(Self(Arc::new(Inner::new(api, eth, Some(sub_endpoint)))))
     }
 
     /// Create a new engine using RPC.
@@ -115,6 +128,7 @@ impl Engine {
     pub async fn new_rpc(
         execution_endpoint: Url,
         eth_endpoint: Url,
+        ws_endpoint: Option<Url>,
         execution_jwt: &str,
     ) -> eyre::Result<Self> {
         let api = Box::new(EngineRpc::new(
@@ -126,12 +140,13 @@ impl Engine {
         // Probe the RPC server to confirm it is reachable.
         eth.check_connectivity().await?;
 
-        Ok(Self::new(api, eth))
+        let sub_endpoint = ws_endpoint.map(|url| SubscriptionEndpoint::Ws { url });
+        Ok(Self(Arc::new(Inner::new(api, eth, sub_endpoint))))
     }
 
     /// Create a new engine with custom API implementations.
     pub fn new(api: Box<dyn EngineAPI>, eth: Box<dyn EthereumAPI>) -> Self {
-        Self(Arc::new(Inner::new(api, eth)))
+        Self(Arc::new(Inner::new(api, eth, None)))
     }
 
     /// Set the function that determines whether Osaka is active at a given timestamp.
@@ -209,6 +224,13 @@ impl Engine {
             .expect("Clock is before UNIX epoch!")
             .as_secs()
     }
+
+    /// Returns the subscription-capable endpoint for the execution layer,
+    /// if one was configured. `None` for test/mock engines or RPC without
+    /// `--execution-ws-endpoint`.
+    pub fn subscription_endpoint(&self) -> Option<&SubscriptionEndpoint> {
+        self.0.subscription_endpoint.as_ref()
+    }
 }
 
 impl Deref for Engine {
@@ -224,6 +246,8 @@ pub struct Inner {
     pub api: Box<dyn EngineAPI>,
     /// Client for Ethereum API.
     pub eth: Box<dyn EthereumAPI>,
+    /// Subscription-capable endpoint for the execution layer.
+    subscription_endpoint: Option<SubscriptionEndpoint>,
     /// Optional function to check if Osaka is active at a given timestamp.
     /// Set after construction via [`Engine::set_is_osaka_active`].
     /// When `None`, defaults to `false` (use V4).
@@ -231,11 +255,15 @@ pub struct Inner {
 }
 
 impl Inner {
-    /// Create a new engine with custom API implementations.
-    fn new(api: Box<dyn EngineAPI>, eth: Box<dyn EthereumAPI>) -> Self {
+    fn new(
+        api: Box<dyn EngineAPI>,
+        eth: Box<dyn EthereumAPI>,
+        subscription_endpoint: Option<SubscriptionEndpoint>,
+    ) -> Self {
         Self {
             api,
             eth,
+            subscription_endpoint,
             is_osaka_active: OnceLock::new(),
         }
     }

--- a/crates/eth-engine/src/lib.rs
+++ b/crates/eth-engine/src/lib.rs
@@ -18,6 +18,7 @@ pub mod capabilities;
 pub mod engine;
 pub mod ipc;
 pub mod json_structures;
+pub mod persistence_meter;
 pub mod retry;
 pub mod rpc;
 
@@ -29,4 +30,5 @@ pub use constants::INITIAL_RETRY_DELAY;
 #[cfg(any(test, feature = "mocks"))]
 pub mod mocks {
     pub use crate::engine::{MockEngineAPI, MockEthereumAPI};
+    pub use crate::persistence_meter::MockPersistenceMeter;
 }

--- a/crates/eth-engine/src/persistence_meter.rs
+++ b/crates/eth-engine/src/persistence_meter.rs
@@ -1,0 +1,764 @@
+// Copyright 2026 Circle Internet Group, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alloy_eips::BlockNumHash;
+use async_trait::async_trait;
+use eyre::{eyre, Context};
+use jsonrpsee::{
+    async_client::Client,
+    core::client::SubscriptionClientT,
+    rpc_params,
+    ws_client::{PingConfig, WsClientBuilder},
+};
+use reth_ipc::client::IpcClientBuilder;
+use tokio::sync::Notify;
+use tracing::{debug, info, warn};
+
+use crate::engine::{EthereumAPI, SubscriptionEndpoint};
+
+const SUBSCRIBE_METHOD: &str = "reth_subscribePersistedBlock";
+const UNSUBSCRIBE_METHOD: &str = "reth_unsubscribePersistedBlock";
+/// Timeout for the initial WebSocket/IPC connection attempt.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout for individual RPC requests on the subscription connection.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Initial delay between reconnection attempts (doubles on each failure, capped).
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
+/// WebSocket ping interval for detecting stale connections.
+const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+/// Cap on exponential reconnect backoff.
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Tracks execution layer block persistence and applies backpressure when the
+/// EL falls behind.
+///
+/// Callers invoke [`wait_for_persisted_block`] after submitting a block to the
+/// EL. The call returns immediately if the EL has already persisted within the
+/// configured threshold, or blocks until persistence catches up. Returns `Err`
+/// on timeout.
+#[cfg_attr(any(test, feature = "mocks"), mockall::automock)]
+#[async_trait]
+pub trait PersistenceMeter: Send + Sync {
+    /// Block until `block_number` (minus the configured threshold) has been
+    /// persisted by the execution layer. Returns immediately if already satisfied.
+    /// Returns `Err` on timeout
+    async fn wait_for_persisted_block(
+        &self,
+        block_number: u64,
+        timeout: Duration,
+    ) -> eyre::Result<()>;
+
+    /// Set a known persisted block height so early wait calls don't block
+    /// unnecessarily. Only reliable at startup before blocks accumulate.
+    fn seed(&self, _block_number: u64) {}
+}
+
+#[async_trait]
+impl<T: PersistenceMeter + ?Sized> PersistenceMeter for &T {
+    async fn wait_for_persisted_block(
+        &self,
+        block_number: u64,
+        timeout: Duration,
+    ) -> eyre::Result<()> {
+        (**self)
+            .wait_for_persisted_block(block_number, timeout)
+            .await
+    }
+
+    fn seed(&self, block_number: u64) {
+        (**self).seed(block_number);
+    }
+}
+pub struct NoopPersistenceMeter;
+
+#[async_trait]
+impl PersistenceMeter for NoopPersistenceMeter {
+    async fn wait_for_persisted_block(
+        &self,
+        _block_number: u64,
+        _timeout: Duration,
+    ) -> eyre::Result<()> {
+        Ok(())
+    }
+}
+
+/// Statuses that the persistence meter internally transitions between
+///
+/// Subscription live and counter reliable. Backpressure enforced.
+const SUBSCRIPTION_STATUS_ACTIVE: u8 = 0;
+/// No live subscription. Backpressure suspended.
+const SUBSCRIPTION_STATUS_RECONNECTING: u8 = 1;
+/// Subscription live but no notification received yet. Backpressure suspended.
+const SUBSCRIPTION_STATUS_CONNECTED: u8 = 2;
+
+struct SharedState {
+    /// Highest block number the EL has confirmed as persisted to disk.
+    last_persisted_block: AtomicU64,
+    /// Wakes waiters when `last_persisted_block` advances or connection state changes.
+    notify: Notify,
+    /// Subscription lifecycle state. Backpressure is only enforced when
+    /// [`SUBSCRIPTION_STATUS_ACTIVE`].
+    subscription_status: AtomicU8,
+}
+
+/// Meter block ingestion throughput using the execution layer's persisted block subscription.
+///
+/// A background task maintains the subscription connection, updates an atomic
+/// counter on each notification, and wakes any waiters via [`Notify`]. This
+/// allows [`wait_for_persisted_block`] to return immediately when the target
+/// block is already persisted, and multiple callers can wait concurrently
+/// without contending on a lock.
+///
+/// In the background, a task will maintain the connection, reconnecting as needed.
+/// When reconnecting, the internal [`subscription_status`] will transition to [`SUBSCRIPTION_STATUS_RECONNECTING`]
+/// which disables backpressure. Upon the first received notification, it will transition back to [`SUBSCRIPTION_STATUS_ACTIVE`],
+/// applying backpressure again.
+///
+/// Seeding the meter with an initial height value will transition it to
+/// [`SUBSCRIPTION_STATUS_ACTIVE`] only if the subscription is already
+/// [`SUBSCRIPTION_STATUS_CONNECTED`]. If reconnecting, the seed updates the
+/// counter but backpressure remains suspended until the subscription is live.
+pub struct PersistedBlockMeter {
+    shared: Arc<SharedState>,
+    /// Number of blocks the EL may lag behind before backpressure applies.
+    persistence_backpressure_threshold: u64,
+    /// Background subscription reader; aborted on drop.
+    _background: tokio::task::JoinHandle<()>,
+}
+
+impl PersistedBlockMeter {
+    async fn new(endpoint: &SubscriptionEndpoint, persistence_backpressure_threshold: u64) -> Self {
+        let initial_connection = connect_and_subscribe(endpoint).await.ok();
+        let status = if initial_connection.is_some() {
+            info!("Persistence meter: subscription connected");
+            SUBSCRIPTION_STATUS_CONNECTED
+        } else {
+            warn!("Persistence meter: initial connection failed; retrying in background");
+            SUBSCRIPTION_STATUS_RECONNECTING
+        };
+
+        let shared = Arc::new(SharedState {
+            last_persisted_block: AtomicU64::new(0),
+            notify: Notify::new(),
+            subscription_status: AtomicU8::new(status),
+        });
+
+        let background = tokio::spawn(background_reader(
+            endpoint.clone(),
+            Arc::clone(&shared),
+            initial_connection,
+        ));
+
+        Self {
+            shared,
+            persistence_backpressure_threshold,
+            _background: background,
+        }
+    }
+}
+
+#[cfg(test)]
+impl PersistedBlockMeter {
+    fn test_instance(persistence_backpressure_threshold: u64) -> Self {
+        let shared = Arc::new(SharedState {
+            last_persisted_block: AtomicU64::new(0),
+            notify: Notify::new(),
+            subscription_status: AtomicU8::new(SUBSCRIPTION_STATUS_ACTIVE),
+        });
+        Self {
+            shared,
+            persistence_backpressure_threshold,
+            _background: tokio::spawn(std::future::pending()),
+        }
+    }
+}
+
+impl Drop for PersistedBlockMeter {
+    fn drop(&mut self) {
+        self._background.abort();
+    }
+}
+
+#[async_trait]
+impl PersistenceMeter for PersistedBlockMeter {
+    fn seed(&self, block_number: u64) {
+        self.shared
+            .last_persisted_block
+            .fetch_max(block_number, Ordering::Release);
+
+        // Only transition to ACTIVE if there's a functioning connection
+        // This is to prevent the situation where the connection can never be
+        // established, yet back pressure would still be applied.
+        let activated = self
+            .shared
+            .subscription_status
+            .compare_exchange(
+                SUBSCRIPTION_STATUS_CONNECTED,
+                SUBSCRIPTION_STATUS_ACTIVE,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok();
+        self.shared.notify.notify_waiters();
+        if activated {
+            info!(
+                persisted_block = block_number,
+                "Persistence meter: seeded and active"
+            );
+        } else {
+            info!(
+                persisted_block = block_number,
+                "Persistence meter: seeded (backpressure deferred until subscription is live)"
+            );
+        }
+    }
+
+    async fn wait_for_persisted_block(
+        &self,
+        block_number: u64,
+        timeout: Duration,
+    ) -> eyre::Result<()> {
+        let target = block_number.saturating_sub(self.persistence_backpressure_threshold);
+        let started_at = Instant::now();
+
+        loop {
+            // Register for notification *before* checking state to avoid
+            // missing an update between the checks and the await.
+            let notified = self.shared.notify.notified();
+
+            // Only enforce backpressure when ACTIVE.
+            let status = self.shared.subscription_status.load(Ordering::Acquire);
+            if status != SUBSCRIPTION_STATUS_ACTIVE {
+                debug!(
+                    requested_block = block_number,
+                    status, "Persistence backpressure skipped: subscription not active"
+                );
+                return Ok(());
+            }
+
+            let current = self.shared.last_persisted_block.load(Ordering::Acquire);
+            // If we're within the configured threshold, proceed
+            if current >= target {
+                debug!(
+                    requested_block = block_number,
+                    persisted_block = current,
+                    "Persistence backpressure satisfied: EL is keeping up"
+                );
+                return Ok(());
+            }
+
+            // Else, wait until timeout is reached
+            let remaining = timeout
+                .checked_sub(started_at.elapsed())
+                .unwrap_or(Duration::ZERO);
+
+            if remaining.is_zero() {
+                return Err(eyre!(
+                    "Persistence backpressure timed out: requested block {block_number}, \
+                     persisted block {current}"
+                ));
+            }
+
+            debug!(
+                requested_block = block_number,
+                persisted_block = current,
+                "Persistence backpressure: waiting for execution layer to catch up"
+            );
+
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                let current = self.shared.last_persisted_block.load(Ordering::Acquire);
+                return Err(eyre!(
+                    "Persistence backpressure timed out: requested block {block_number}, \
+                     persisted block {current}"
+                ));
+            }
+        }
+    }
+}
+
+/// Background task that reads persisted block notifications from the execution
+/// layer and updates the shared atomic counter. Reconnects automatically on error.
+///
+/// If `initial_connection` is `None`, the task begins by connecting via `reconnect()`.
+async fn background_reader(
+    endpoint: SubscriptionEndpoint,
+    shared: Arc<SharedState>,
+    initial_connection: Option<(Client, jsonrpsee::core::client::Subscription<BlockNumHash>)>,
+) {
+    let (mut client, mut subscription) = match initial_connection {
+        Some(conn) => conn,
+        None => reconnect(&endpoint).await,
+    };
+
+    loop {
+        match subscription.next().await {
+            Some(Ok(block)) => {
+                // If this is the first notification received since re-establishing
+                // a connection, transition to ACTIVE
+                let prev_status = shared
+                    .subscription_status
+                    .swap(SUBSCRIPTION_STATUS_ACTIVE, Ordering::Release);
+                if prev_status != SUBSCRIPTION_STATUS_ACTIVE {
+                    info!(
+                        persisted_block = block.number,
+                        "Persistence meter: subscription now active"
+                    );
+                }
+                let prev = shared
+                    .last_persisted_block
+                    .fetch_max(block.number, Ordering::Release);
+                // Only notify if we've advanced, in case they arrive out-of-order
+                if block.number > prev {
+                    shared.notify.notify_waiters();
+                }
+                debug!(
+                    persisted_block = block.number,
+                    "Persistence meter: received persisted block notification"
+                );
+            }
+            Some(Err(error)) => {
+                warn!(
+                    %error,
+                    "Persistence meter: subscription errored; reconnecting"
+                );
+                shared
+                    .subscription_status
+                    .store(SUBSCRIPTION_STATUS_RECONNECTING, Ordering::Release);
+                shared.notify.notify_waiters();
+                drop(subscription);
+                drop(client);
+                (client, subscription) = reconnect(&endpoint).await;
+            }
+            None => {
+                warn!("Persistence meter: subscription closed; reconnecting");
+                shared
+                    .subscription_status
+                    .store(SUBSCRIPTION_STATUS_RECONNECTING, Ordering::Release);
+                shared.notify.notify_waiters();
+                drop(subscription);
+                drop(client);
+                (client, subscription) = reconnect(&endpoint).await;
+            }
+        }
+    }
+}
+
+/// Retry the subscription connection with exponential backoff (1s → 60s cap).
+///
+/// Retries forever. This runs in the background task, not in the caller's
+/// loop, so it never directly blocks block processing.
+async fn reconnect(
+    endpoint: &SubscriptionEndpoint,
+) -> (Client, jsonrpsee::core::client::Subscription<BlockNumHash>) {
+    let mut backoff = RECONNECT_BACKOFF;
+    loop {
+        match connect_and_subscribe(endpoint).await {
+            Ok((client, subscription)) => {
+                info!("Persistence meter: reconnected to persisted block subscription");
+                return (client, subscription);
+            }
+            Err(error) => {
+                warn!(
+                    %error,
+                    backoff = ?backoff,
+                    "Persistence meter: reconnection failed; retrying"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            }
+        }
+    }
+}
+
+/// Establish a fresh connection and subscribe to persisted block
+/// notifications. Used both for the initial connection in
+/// [`PersistedBlockMeter::new`] and for reconnection attempts in
+/// [`reconnect`].
+async fn connect_and_subscribe(
+    endpoint: &SubscriptionEndpoint,
+) -> eyre::Result<(Client, jsonrpsee::core::client::Subscription<BlockNumHash>)> {
+    let client = connect_client(endpoint).await?;
+    let subscription = client
+        .subscribe(SUBSCRIBE_METHOD, rpc_params![], UNSUBSCRIBE_METHOD)
+        .await
+        .wrap_err("Failed to subscribe to persisted block notifications")?;
+
+    Ok((client, subscription))
+}
+
+/// Open a JSON-RPC client to the execution layer.
+///
+/// Dispatches on [`SubscriptionEndpoint`]: IPC connects to a Unix socket,
+/// WS connects over WebSocket with 'keep-alive' ping.
+async fn connect_client(endpoint: &SubscriptionEndpoint) -> eyre::Result<Client> {
+    match endpoint {
+        SubscriptionEndpoint::Ipc { socket_path } => IpcClientBuilder::default()
+            .request_timeout(REQUEST_TIMEOUT)
+            .build(socket_path)
+            .await
+            .wrap_err_with(|| format!("Failed to connect to IPC socket {socket_path}")),
+        SubscriptionEndpoint::Ws { url } => WsClientBuilder::default()
+            .request_timeout(REQUEST_TIMEOUT)
+            .connection_timeout(CONNECT_TIMEOUT)
+            .enable_ws_ping(
+                PingConfig::new()
+                    .ping_interval(WS_PING_INTERVAL)
+                    .inactive_limit(WS_PING_INTERVAL * 2),
+            )
+            .build(url)
+            .await
+            .wrap_err_with(|| format!("Failed to connect to WebSocket endpoint {url}")),
+    }
+}
+
+/// Create a persistence meter. The initial connection is attempted eagerly;
+/// if it fails, the background task retries automatically.
+///
+/// The meter starts without a known persisted height. Call
+/// [`PersistenceMeter::seed`] after creation if a reliable starting
+/// height is available (e.g. at startup via `eth_getBlockByNumber`).
+pub async fn create(
+    endpoint: &SubscriptionEndpoint,
+    persistence_backpressure_threshold: u64,
+) -> Box<dyn PersistenceMeter> {
+    let m = PersistedBlockMeter::new(endpoint, persistence_backpressure_threshold).await;
+    info!(
+        backpressure_threshold = persistence_backpressure_threshold,
+        "Persistence meter: active"
+    );
+    Box::new(m)
+}
+
+/// Create a persistence meter with graceful degradation. Falls back to a no-op
+/// meter (no backpressure) when:
+/// - `enabled` is false
+/// - no subscription endpoint is configured
+///
+/// The meter starts without a known persisted height. Call
+/// [`PersistenceMeter::seed`] after creation if a reliable starting
+/// height is available (e.g. at startup via `eth_getBlockByNumber`).
+pub async fn create_with_fallback(
+    enabled: bool,
+    endpoint: Option<&SubscriptionEndpoint>,
+    persistence_backpressure_threshold: u64,
+) -> Box<dyn PersistenceMeter> {
+    if !enabled {
+        info!("Persistence meter: disabled, --execution-persistence-backpressure not set");
+        return Box::new(NoopPersistenceMeter);
+    }
+    let Some(endpoint) = endpoint else {
+        info!("Persistence meter: disabled, no subscription endpoint configured");
+        return Box::new(NoopPersistenceMeter);
+    };
+    create(endpoint, persistence_backpressure_threshold).await
+}
+
+/// Seed the meter with the EL's current block height. Only reliable at
+/// startup before blocks accumulate, since `eth_getBlockByNumber("latest")`
+/// may return un-persisted heights during steady-state operation.
+pub async fn seed_from_latest_block(meter: &dyn PersistenceMeter, eth: &dyn EthereumAPI) {
+    match eth.get_block_by_number("latest").await {
+        Ok(Some(block)) => {
+            meter.seed(block.block_number);
+        }
+        Ok(None) => {
+            warn!("Persistence meter: seed skipped: Ethereum API returned no latest block");
+        }
+        Err(error) => {
+            warn!(
+                %error,
+                "Persistence meter: seed skipped: failed to fetch latest Ethereum block"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::MockEthereumAPI;
+    use eyre::eyre;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
+    use reqwest::Url;
+    use std::sync::atomic::Ordering;
+
+    #[tokio::test]
+    async fn noop_meter_always_succeeds() {
+        let meter = NoopPersistenceMeter;
+        assert!(meter
+            .wait_for_persisted_block(100, TEST_TIMEOUT)
+            .await
+            .is_ok());
+        assert!(meter
+            .wait_for_persisted_block(0, TEST_TIMEOUT)
+            .await
+            .is_ok());
+        assert!(meter
+            .wait_for_persisted_block(u64::MAX, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_with_fallback_returns_noop_when_disabled() {
+        let endpoint = SubscriptionEndpoint::Ws {
+            url: Url::parse("ws://localhost:8546").unwrap(),
+        };
+        let meter = create_with_fallback(false, Some(&endpoint), 100).await;
+        assert!(meter
+            .wait_for_persisted_block(1000, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_with_fallback_returns_noop_when_no_endpoint() {
+        let meter = create_with_fallback(true, None, 100).await;
+        assert!(meter
+            .wait_for_persisted_block(1000, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_with_fallback_suspends_backpressure_on_connection_failure() {
+        let endpoint = SubscriptionEndpoint::Ws {
+            url: Url::parse("ws://192.0.2.1:1").unwrap(), // unreachable
+        };
+        let meter = create_with_fallback(true, Some(&endpoint), 5).await;
+        assert!(meter
+            .wait_for_persisted_block(1000, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_retries_on_unreachable_endpoint() {
+        let endpoint = SubscriptionEndpoint::Ws {
+            url: Url::parse("ws://192.0.2.1:1").unwrap(),
+        };
+        let meter = create(&endpoint, 5).await;
+        // Initial connection failed — backpressure suspended (not ACTIVE)
+        assert!(meter
+            .wait_for_persisted_block(1000, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_already_persisted() {
+        let meter = PersistedBlockMeter::test_instance(5);
+        meter
+            .shared
+            .last_persisted_block
+            .store(100, Ordering::Release);
+
+        // block_number=10, threshold=5, target=5 — persisted=100 >= 5
+        assert!(meter
+            .wait_for_persisted_block(10, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_threshold_covers_gap() {
+        let meter = PersistedBlockMeter::test_instance(10);
+        meter
+            .shared
+            .last_persisted_block
+            .store(0, Ordering::Release);
+
+        // block_number=5, threshold=10, target=5.saturating_sub(10)=0 — persisted=0 >= 0
+        assert!(meter
+            .wait_for_persisted_block(5, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_times_out_when_not_persisted() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .last_persisted_block
+            .store(5, Ordering::Release);
+
+        // target=100, persisted=5 — will never catch up
+        let result = meter.wait_for_persisted_block(100, SHORT_TIMEOUT).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_skips_backpressure_when_reconnecting() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        // persisted=0, target=100 — would normally block and time out
+        meter
+            .shared
+            .subscription_status
+            .store(SUBSCRIPTION_STATUS_RECONNECTING, Ordering::Release);
+        assert!(meter
+            .wait_for_persisted_block(100, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_enforces_backpressure_when_active() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .last_persisted_block
+            .store(5, Ordering::Release);
+        // Status is ACTIVE (default), persisted=5, target=100 — should block and time out
+        let result = meter.wait_for_persisted_block(100, SHORT_TIMEOUT).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn seed_transitions_connected_to_active() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .subscription_status
+            .store(SUBSCRIPTION_STATUS_CONNECTED, Ordering::Release);
+        meter.seed(100);
+        assert_eq!(
+            meter.shared.subscription_status.load(Ordering::Acquire),
+            SUBSCRIPTION_STATUS_ACTIVE
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_does_not_activate_when_reconnecting() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .subscription_status
+            .store(SUBSCRIPTION_STATUS_RECONNECTING, Ordering::Release);
+        meter.seed(100);
+        assert_eq!(
+            meter.shared.subscription_status.load(Ordering::Acquire),
+            SUBSCRIPTION_STATUS_RECONNECTING
+        );
+        assert_eq!(
+            meter.shared.last_persisted_block.load(Ordering::Acquire),
+            100
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_skips_backpressure_when_connected_but_not_active() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .subscription_status
+            .store(SUBSCRIPTION_STATUS_CONNECTED, Ordering::Release);
+        assert!(meter
+            .wait_for_persisted_block(100, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn wait_wakes_up_on_notify() {
+        let meter = PersistedBlockMeter::test_instance(0);
+        meter
+            .shared
+            .last_persisted_block
+            .store(0, Ordering::Release);
+
+        let shared = Arc::clone(&meter.shared);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            shared.last_persisted_block.store(50, Ordering::Release);
+            shared.notify.notify_waiters();
+        });
+
+        assert!(meter
+            .wait_for_persisted_block(50, TEST_TIMEOUT)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn seed_updates_persisted_block() {
+        let meter = PersistedBlockMeter::test_instance(5);
+        assert_eq!(meter.shared.last_persisted_block.load(Ordering::Acquire), 0);
+
+        meter.seed(42);
+        assert_eq!(
+            meter.shared.last_persisted_block.load(Ordering::Acquire),
+            42
+        );
+
+        // seed should only increase, never decrease
+        meter.seed(10);
+        assert_eq!(
+            meter.shared.last_persisted_block.load(Ordering::Acquire),
+            42
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_from_latest_block_updates_meter() {
+        let meter = PersistedBlockMeter::test_instance(5);
+
+        let mut eth = MockEthereumAPI::new();
+        eth.expect_get_block_by_number().return_once(|_| {
+            Ok(Some(crate::json_structures::ExecutionBlock {
+                block_number: 99,
+                block_hash: Default::default(),
+                parent_hash: Default::default(),
+                timestamp: 0,
+            }))
+        });
+
+        seed_from_latest_block(&meter, &eth).await;
+        assert_eq!(
+            meter.shared.last_persisted_block.load(Ordering::Acquire),
+            99
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_from_latest_block_handles_no_block() {
+        let meter = PersistedBlockMeter::test_instance(5);
+
+        let mut eth = MockEthereumAPI::new();
+        eth.expect_get_block_by_number().return_once(|_| Ok(None));
+
+        seed_from_latest_block(&meter, &eth).await;
+        assert_eq!(meter.shared.last_persisted_block.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn seed_from_latest_block_handles_error() {
+        let meter = PersistedBlockMeter::test_instance(5);
+
+        let mut eth = MockEthereumAPI::new();
+        eth.expect_get_block_by_number()
+            .return_once(|_| Err(eyre!("connection refused")));
+
+        seed_from_latest_block(&meter, &eth).await;
+        assert_eq!(meter.shared.last_persisted_block.load(Ordering::Acquire), 0);
+    }
+}

--- a/crates/eth-engine/tests/integration.rs
+++ b/crates/eth-engine/tests/integration.rs
@@ -231,6 +231,7 @@ async fn test_engine() {
         let engine = Engine::new_rpc(
             Url::parse("http://localhost:8551").unwrap(),
             Url::parse("http://localhost:8545").unwrap(),
+            None,
             jwt_path.to_str().unwrap(),
         )
         .await

--- a/crates/execution-config/src/follow.rs
+++ b/crates/execution-config/src/follow.rs
@@ -18,52 +18,36 @@
 
 use eyre::{eyre, Result};
 use reth_network_peers::TrustedPeer;
-use std::str::FromStr;
 
-use arc_shared::chain_ids::{DEVNET_CHAIN_ID, LOCALDEV_CHAIN_ID, TESTNET_CHAIN_ID};
+use arc_shared::chain_ids::{LOCALDEV_CHAIN_ID, TESTNET_CHAIN_ID};
 
-/// Returns the WebSocket URL for the given chain ID.
+/// Returns the RPC URL for the given chain ID.
 pub fn url_for_chain_id(chain_id: u64) -> Result<String> {
     let url = match chain_id {
-        // FIXME: use production URLs
-        TESTNET_CHAIN_ID => "wss://testnet.circle-chain.com:8546",
+        TESTNET_CHAIN_ID => "https://rpc.quicknode.testnet.arc.network/",
         LOCALDEV_CHAIN_ID => "ws://localhost:8546",
-        DEVNET_CHAIN_ID => "wss://devnet.circle-chain.com:8546",
         _ => return Err(eyre!("Unsupported chain for follow mode: {}", chain_id)),
     };
     Ok(url.to_string())
 }
 
 /// Returns the trusted peers (enode URLs) for the given chain ID.
+///
+/// Currently returns an empty list for all chains. Trusted peer discovery
+/// is not needed when running with `--rpc.forwarder` (the recommended
+/// setup). If devp2p backfill is needed in the future, add real enode IDs
+/// here.
 pub fn trusted_peers_for_chain_id(chain_id: u64) -> Result<Vec<TrustedPeer>> {
-    // FIXME: use production URLs
-    let peer_strs: Vec<&str> = match chain_id {
-        TESTNET_CHAIN_ID => vec![
-            "enode://placeholder@testnet-boot1.circle-chain.com:30303",
-            "enode://placeholder@testnet-boot2.circle-chain.com:30303",
-        ],
-        LOCALDEV_CHAIN_ID => vec![],
-        DEVNET_CHAIN_ID => vec![
-            "enode://placeholder@devnet-boot1.circle-chain.com:30303",
-            "enode://placeholder@devnet-boot2.circle-chain.com:30303",
-        ],
-        _ => return Err(eyre!("Unsupported chain for follow mode: {}", chain_id)),
-    };
-
-    // Parse each peer string into a TrustedPeer
-    let mut peers = Vec::new();
-    for peer_str in peer_strs {
-        let peer = TrustedPeer::from_str(peer_str)
-            .map_err(|e| eyre!("Failed to parse trusted peer '{}': {}", peer_str, e))?;
-        peers.push(peer);
+    match chain_id {
+        TESTNET_CHAIN_ID | LOCALDEV_CHAIN_ID => Ok(Vec::new()),
+        _ => Err(eyre!("Unsupported chain for follow mode: {}", chain_id)),
     }
-
-    Ok(peers)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arc_shared::chain_ids::DEVNET_CHAIN_ID;
 
     #[test]
     fn test_url_for_chain_id_localdev() {
@@ -73,14 +57,14 @@ mod tests {
 
     #[test]
     fn test_url_for_chain_id_devnet() {
-        let url = url_for_chain_id(DEVNET_CHAIN_ID).unwrap();
-        assert_eq!(url, "wss://devnet.circle-chain.com:8546");
+        let result = url_for_chain_id(DEVNET_CHAIN_ID);
+        assert!(result.is_err());
     }
 
     #[test]
     fn test_url_for_chain_id_testnet() {
         let url = url_for_chain_id(TESTNET_CHAIN_ID).unwrap();
-        assert_eq!(url, "wss://testnet.circle-chain.com:8546");
+        assert_eq!(url, "https://rpc.quicknode.testnet.arc.network/");
     }
 
     #[test]
@@ -101,24 +85,14 @@ mod tests {
 
     #[test]
     fn test_trusted_peers_for_chain_id_devnet() {
-        // Currently returns an error because the peer strings contain placeholder node IDs
         let result = trusted_peers_for_chain_id(DEVNET_CHAIN_ID);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse trusted peer"));
     }
 
     #[test]
     fn test_trusted_peers_for_chain_id_testnet() {
-        // Currently returns an error because the peer strings contain placeholder node IDs
-        let result = trusted_peers_for_chain_id(TESTNET_CHAIN_ID);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse trusted peer"));
+        let peers = trusted_peers_for_chain_id(TESTNET_CHAIN_ID).unwrap();
+        assert_eq!(peers.len(), 0);
     }
 
     #[test]

--- a/crates/malachite-app/src/config.rs
+++ b/crates/malachite-app/src/config.rs
@@ -59,12 +59,15 @@ impl<'a> EngineConfig<'a> {
             EngineConfig::Rpc(EthRpcConfig {
                 eth_rpc_endpoint,
                 execution_endpoint,
+                execution_ws_endpoint,
                 execution_jwt,
             }) => {
-                (|| {
+                let ws_endpoint = execution_ws_endpoint;
+                (move || {
                     Engine::new_rpc(
                         execution_endpoint.clone(),
                         eth_rpc_endpoint.clone(),
+                        ws_endpoint.clone(),
                         execution_jwt,
                     )
                 })
@@ -86,6 +89,7 @@ pub struct EthIpcConfig<'a> {
 pub struct EthRpcConfig<'a> {
     pub eth_rpc_endpoint: &'a Url,
     pub execution_endpoint: &'a Url,
+    pub execution_ws_endpoint: Option<Url>,
     pub execution_jwt: &'a str,
 }
 
@@ -110,6 +114,8 @@ pub struct StartConfig {
     pub eth_rpc_endpoint: Option<Url>,
     /// The execution endpoint
     pub execution_endpoint: Option<Url>,
+    /// The execution WebSocket endpoint
+    pub execution_ws_endpoint: Option<Url>,
     /// The execution JWT
     pub execution_jwt: Option<String>,
     /// The bind address for the pprof server
@@ -148,9 +154,15 @@ impl StartConfig {
             self.execution_endpoint.as_ref(),
             self.execution_jwt.as_ref(),
         ) {
+            let ws_endpoint = self
+                .execution_ws_endpoint
+                .clone()
+                .or_else(|| derive_ws_url(eth_rpc_endpoint));
+
             Some(EngineConfig::Rpc(EthRpcConfig {
                 eth_rpc_endpoint,
                 execution_endpoint,
+                execution_ws_endpoint: ws_endpoint,
                 execution_jwt,
             }))
         } else {
@@ -165,4 +177,21 @@ impl StartConfig {
             DbUpgrade::Perform
         }
     }
+}
+
+/// Derive a WebSocket URL from an HTTP RPC URL using the reth convention:
+/// `http(s)://host:port` → `ws(s)://host:(port+1)`.
+///
+/// Same convention used by `--follow.endpoint` (see [`SyncEndpointUrl::websocket`]).
+/// Returns `None` if the URL has no explicit port or an unsupported scheme.
+fn derive_ws_url(http_url: &Url) -> Option<Url> {
+    let mut ws_url = http_url.clone();
+    match http_url.scheme() {
+        "http" => ws_url.set_scheme("ws").ok()?,
+        "https" => ws_url.set_scheme("wss").ok()?,
+        _ => return None,
+    }
+    let port = http_url.port()?;
+    ws_url.set_port(Some(port + 1)).ok()?;
+    Some(ws_url)
 }

--- a/crates/malachite-app/src/config.rs
+++ b/crates/malachite-app/src/config.rs
@@ -191,7 +191,44 @@ fn derive_ws_url(http_url: &Url) -> Option<Url> {
         "https" => ws_url.set_scheme("wss").ok()?,
         _ => return None,
     }
-    let port = http_url.port()?;
-    ws_url.set_port(Some(port + 1)).ok()?;
+    let port = http_url.port()?.checked_add(1)?;
+    ws_url.set_port(Some(port)).ok()?;
     Some(ws_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_ws_url_increments_port() {
+        let http = Url::parse("http://localhost:8545").unwrap();
+        let ws = derive_ws_url(&http).unwrap();
+        assert_eq!(ws.as_str(), "ws://localhost:8546/");
+    }
+
+    #[test]
+    fn derive_ws_url_https_to_wss() {
+        let https = Url::parse("https://localhost:8545").unwrap();
+        let wss = derive_ws_url(&https).unwrap();
+        assert_eq!(wss.as_str(), "wss://localhost:8546/");
+    }
+
+    #[test]
+    fn derive_ws_url_returns_none_on_port_overflow() {
+        let http = Url::parse("http://localhost:65535").unwrap();
+        assert!(derive_ws_url(&http).is_none());
+    }
+
+    #[test]
+    fn derive_ws_url_returns_none_without_port() {
+        let http = Url::parse("http://localhost").unwrap();
+        assert!(derive_ws_url(&http).is_none());
+    }
+
+    #[test]
+    fn derive_ws_url_returns_none_for_unsupported_scheme() {
+        let ftp = Url::parse("ftp://localhost:8545").unwrap();
+        assert!(derive_ws_url(&ftp).is_none());
+    }
 }

--- a/crates/malachite-app/src/handlers/consensus_ready.rs
+++ b/crates/malachite-app/src/handlers/consensus_ready.rs
@@ -18,10 +18,14 @@ use eyre::{eyre, Context};
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
+/// Timeout when blocked waiting for EL persistence to catch up.
+const REPLAY_PERSISTENCE_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 use arc_consensus_types::{ArcContext, ConsensusParams, Height, ValidatorSet, ValueSyncConfig};
 use arc_eth_engine::capabilities::check_capabilities;
 use arc_eth_engine::engine::{Engine, EngineAPI, EthereumAPI};
 use arc_eth_engine::json_structures::ExecutionBlock;
+use arc_eth_engine::persistence_meter::{self, PersistenceMeter};
 use malachitebft_app_channel::Reply;
 use malachitebft_core_types::HeightParams;
 
@@ -49,6 +53,19 @@ pub async fn handle(
     let payload_validator = EnginePayloadValidator::new(engine, metrics);
     let block_finalizer = EngineBlockFinalizer::new(engine, stats, metrics);
 
+    let execution_config = &state.config().execution;
+    let persistence_meter = persistence_meter::create_with_fallback(
+        execution_config.persistence_backpressure,
+        engine.subscription_endpoint(),
+        execution_config.persistence_backpressure_threshold,
+    )
+    .await;
+
+    // Seed with the current EL height. Safe at startup since all blocks are
+    // persisted before the node begins replaying.
+    persistence_meter::seed_from_latest_block(persistence_meter.as_ref(), engine.eth.as_ref())
+        .await;
+
     let (next_height, next_validator_set, next_consensus_params, previous_block) =
         on_consensus_ready(
             metrics,
@@ -59,6 +76,7 @@ pub async fn handle(
             block_finalizer,
             engine.api.as_ref(),
             engine.eth.as_ref(),
+            persistence_meter.as_ref(),
             max_pending_proposals,
         )
         .await?;
@@ -90,6 +108,7 @@ async fn on_consensus_ready(
     block_finalizer: impl BlockFinalizer,
     engine_api: impl EngineAPI,
     ethereum_api: impl EthereumAPI,
+    persistence_meter: impl PersistenceMeter,
     max_pending_proposals: usize,
 ) -> eyre::Result<(Height, ValidatorSet, ConsensusParams, ExecutionBlock)> {
     // Perform handshake and replay any missing blocks
@@ -104,6 +123,7 @@ async fn on_consensus_ready(
         &ethereum_api,
         &certificates_repository,
         &payloads_repository,
+        persistence_meter,
         metrics,
     )
     .await?;
@@ -294,6 +314,7 @@ struct HandshakeResult {
     next_height: Height,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handshake_and_replay(
     payload_validator: impl PayloadValidator,
     block_finalizer: impl BlockFinalizer,
@@ -301,6 +322,7 @@ async fn handshake_and_replay(
     ethereum_api: impl EthereumAPI,
     certificates_repository: impl CertificatesRepository,
     payloads_repository: impl PayloadsRepository,
+    persistence_meter: impl PersistenceMeter,
     metrics: &AppMetrics,
 ) -> eyre::Result<HandshakeResult> {
     // Node start-up: https://hackmd.io/@danielrachi/engine_api#Node-startup
@@ -366,7 +388,22 @@ async fn handshake_and_replay(
         )
         .await
         {
-            Ok(block) => latest_block = block,
+            Ok(block) => {
+                latest_block = block;
+                if let Err(e) = persistence_meter
+                    .wait_for_persisted_block(
+                        latest_block.block_number,
+                        REPLAY_PERSISTENCE_WAIT_TIMEOUT,
+                    )
+                    .await
+                {
+                    error!(
+                        block_number = latest_block.block_number,
+                        %e,
+                        "🔄 Replay: persistence backpressure timed out, proceeding"
+                    );
+                }
+            }
             Err(ReplayBlockError::PayloadMissing(h)) => {
                 warn!(height = %h, latest_height_cons = %latest_height_cons, "🔄 Handshake: payload missing, triggering checkpoint sync");
 
@@ -468,7 +505,8 @@ mod tests {
     use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
     use arc_consensus_types::{ValidatorSet, B256};
     use arc_eth_engine::capabilities::EngineCapabilities;
-    use arc_eth_engine::mocks::{MockEngineAPI, MockEthereumAPI};
+    use arc_eth_engine::mocks::{MockEngineAPI, MockEthereumAPI, MockPersistenceMeter};
+    use arc_eth_engine::persistence_meter::NoopPersistenceMeter;
     use eyre::eyre;
     use mockall::predicate::*;
 
@@ -601,6 +639,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -675,6 +714,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -689,6 +729,200 @@ mod tests {
         assert_eq!(latest_height, cl_height);
         assert_eq!(next_height, cl_height.increment());
         assert_eq!(metrics.get_handshake_replay_blocks(), expected_replayed);
+    }
+
+    #[tokio::test]
+    async fn test_replay_checks_persistence_after_each_replayed_block_for_small_gap() {
+        let el_height = 3u64;
+        let cl_height = Height::new(5);
+        let latest_block_el = test_execution_block(el_height, 1000);
+
+        let mut payload_validator = MockPayloadValidator::new();
+        payload_validator
+            .expect_validate_payload()
+            .times(2)
+            .returning(|_| Ok(PayloadValidationResult::Valid));
+
+        let mut block_finalizer = MockBlockFinalizer::new();
+        block_finalizer
+            .expect_finalize_decided_block()
+            .times(2)
+            .returning(|height, _| {
+                let h = height.as_u64();
+                let block = test_execution_block(h, 1000 + h);
+                Ok((block, block.block_hash))
+            });
+
+        let engine_api = setup_mock_engine_api_success();
+        let ethereum_api = setup_mock_ethereum_api_with_block(latest_block_el, cl_height.as_u64());
+
+        let mut certificates_repo = MockCertificatesRepository::new();
+        certificates_repo
+            .expect_max_height()
+            .return_once(move || Ok(Some(cl_height)));
+
+        let mut payloads_repo = MockPayloadsRepository::new();
+        payloads_repo
+            .expect_get()
+            .times(2)
+            .returning(|height| Ok(Some(test_payload(height.as_u64(), 1000 + height.as_u64()))));
+
+        let mut persistence_meter = MockPersistenceMeter::new();
+        let mut sequence = mockall::Sequence::new();
+        persistence_meter
+            .expect_wait_for_persisted_block()
+            .withf(|&block, _| block == 4)
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_, _| Ok(()));
+        persistence_meter
+            .expect_wait_for_persisted_block()
+            .withf(|&block, _| block == 5)
+            .times(1)
+            .in_sequence(&mut sequence)
+            .return_once(|_, _| Ok(()));
+
+        let metrics = test_metrics();
+
+        let result = handshake_and_replay(
+            &payload_validator,
+            &block_finalizer,
+            &engine_api,
+            &ethereum_api,
+            &certificates_repo,
+            &payloads_repo,
+            &persistence_meter,
+            &metrics,
+        )
+        .await;
+
+        let HandshakeResult { previous_block, .. } = result.unwrap();
+        assert_eq!(previous_block.block_number, cl_height.as_u64());
+    }
+
+    #[tokio::test]
+    async fn test_replay_checks_persistence_after_each_replayed_block() {
+        let el_height = 3u64;
+        let cl_height = Height::new(13);
+        let latest_block_el = test_execution_block(el_height, 1000);
+
+        let mut payload_validator = MockPayloadValidator::new();
+        payload_validator
+            .expect_validate_payload()
+            .times(10)
+            .returning(|_| Ok(PayloadValidationResult::Valid));
+
+        let mut block_finalizer = MockBlockFinalizer::new();
+        block_finalizer
+            .expect_finalize_decided_block()
+            .times(10)
+            .returning(|height, _| {
+                let h = height.as_u64();
+                let block = test_execution_block(h, 1000 + h);
+                Ok((block, block.block_hash))
+            });
+
+        let engine_api = setup_mock_engine_api_success();
+        let ethereum_api = setup_mock_ethereum_api_with_block(latest_block_el, cl_height.as_u64());
+
+        let mut certificates_repo = MockCertificatesRepository::new();
+        certificates_repo
+            .expect_max_height()
+            .return_once(move || Ok(Some(cl_height)));
+
+        let mut payloads_repo = MockPayloadsRepository::new();
+        payloads_repo
+            .expect_get()
+            .times(10)
+            .returning(|height| Ok(Some(test_payload(height.as_u64(), 1000 + height.as_u64()))));
+
+        let mut persistence_meter = MockPersistenceMeter::new();
+        let mut sequence = mockall::Sequence::new();
+        for height in 4u64..=13 {
+            persistence_meter
+                .expect_wait_for_persisted_block()
+                .withf(move |&block, _| block == height)
+                .times(1)
+                .in_sequence(&mut sequence)
+                .return_once(|_, _| Ok(()));
+        }
+
+        let metrics = test_metrics();
+
+        let result = handshake_and_replay(
+            &payload_validator,
+            &block_finalizer,
+            &engine_api,
+            &ethereum_api,
+            &certificates_repo,
+            &payloads_repo,
+            &persistence_meter,
+            &metrics,
+        )
+        .await;
+
+        let HandshakeResult { previous_block, .. } = result.unwrap();
+        assert_eq!(previous_block.block_number, cl_height.as_u64());
+    }
+
+    #[tokio::test]
+    async fn test_replay_proceeds_when_persistence_meter_fails() {
+        let el_height = 4u64;
+        let cl_height = Height::new(5);
+        let latest_block_el = test_execution_block(el_height, 1000);
+        let payload_to_replay = test_payload(5, 1100);
+
+        let mut payload_validator = MockPayloadValidator::new();
+        payload_validator
+            .expect_validate_payload()
+            .return_once(|_| Ok(PayloadValidationResult::Valid));
+
+        let mut block_finalizer = MockBlockFinalizer::new();
+        block_finalizer
+            .expect_finalize_decided_block()
+            .return_once(|height, _| {
+                let h = height.as_u64();
+                let block = test_execution_block(h, 1000 + h);
+                Ok((block, block.block_hash))
+            });
+
+        let engine_api = setup_mock_engine_api_success();
+        let ethereum_api = setup_mock_ethereum_api_with_block(latest_block_el, cl_height.as_u64());
+
+        let mut certificates_repo = MockCertificatesRepository::new();
+        certificates_repo
+            .expect_max_height()
+            .return_once(move || Ok(Some(cl_height)));
+
+        let mut payloads_repo = MockPayloadsRepository::new();
+        payloads_repo
+            .expect_get()
+            .return_once(move |_| Ok(Some(payload_to_replay)));
+
+        let mut persistence_meter = MockPersistenceMeter::new();
+        persistence_meter
+            .expect_wait_for_persisted_block()
+            .withf(|&block, _| block == 5)
+            .times(1)
+            .return_once(|_, _| Err(eyre!("persistence meter failed")));
+
+        let metrics = test_metrics();
+
+        let result = handshake_and_replay(
+            &payload_validator,
+            &block_finalizer,
+            &engine_api,
+            &ethereum_api,
+            &certificates_repo,
+            &payloads_repo,
+            &persistence_meter,
+            &metrics,
+        )
+        .await;
+
+        // Meter error is logged but replay proceeds
+        let HandshakeResult { previous_block, .. } = result.unwrap();
+        assert_eq!(previous_block.block_number, cl_height.as_u64());
     }
 
     async fn do_multiple_block_replay(num_blocks: usize) {
@@ -736,6 +970,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -794,6 +1029,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -836,6 +1072,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -867,6 +1104,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -912,6 +1150,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -960,6 +1199,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1008,6 +1248,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1039,6 +1280,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1079,6 +1321,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1140,6 +1383,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1178,6 +1422,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1216,6 +1461,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;
@@ -1273,6 +1519,7 @@ mod tests {
             block_finalizer,
             &engine_api,
             &ethereum_api,
+            NoopPersistenceMeter,
             10,
         )
         .await
@@ -1395,6 +1642,7 @@ mod tests {
             &ethereum_api,
             &certificates_repo,
             &payloads_repo,
+            NoopPersistenceMeter,
             &metrics,
         )
         .await;

--- a/crates/malachite-app/src/main.rs
+++ b/crates/malachite-app/src/main.rs
@@ -25,7 +25,8 @@ use eyre::{eyre, Result};
 use tracing::{info, trace};
 
 use arc_consensus_types::{
-    Config, Height, MetricsConfig, PruningConfig, RpcConfig, RuntimeConfig, SigningConfig,
+    Config, ExecutionConfig, Height, MetricsConfig, PruningConfig, RpcConfig, RuntimeConfig,
+    SigningConfig,
 };
 use arc_node_consensus::hardcoded_config;
 use arc_node_consensus::node::{App, StartConfig};
@@ -174,6 +175,11 @@ fn build_config_from_cli(cmd: &StartCmd, logging: config::LoggingConfig) -> Resu
         certificates_before: Height::new(cmd.prune_certificates_before),
     };
 
+    let execution = ExecutionConfig {
+        persistence_backpressure: cmd.execution_persistence_backpressure,
+        persistence_backpressure_threshold: cmd.execution_persistence_backpressure_threshold,
+    };
+
     Ok(Config {
         moniker: cmd.get_moniker(),
         logging,
@@ -183,6 +189,7 @@ fn build_config_from_cli(cmd: &StartCmd, logging: config::LoggingConfig) -> Resu
         runtime,
         prune,
         rpc,
+        execution,
         signing: build_signing_config(cmd)?,
     })
 }
@@ -222,6 +229,7 @@ fn start(args: &Args, cmd: &StartCmd, logging: config::LoggingConfig) -> Result<
         execution_socket: cmd.execution_socket.clone(),
         eth_rpc_endpoint: cmd.eth_rpc_endpoint.clone(),
         execution_endpoint: cmd.execution_endpoint.clone(),
+        execution_ws_endpoint: cmd.execution_ws_endpoint.clone(),
         execution_jwt: cmd.execution_jwt.clone(),
         pprof_bind_address: Some(cmd.pprof_addr.parse()?),
         suggested_fee_recipient: cmd.suggested_fee_recipient,

--- a/crates/malachite-cli/src/cmd/start.rs
+++ b/crates/malachite-cli/src/cmd/start.rs
@@ -160,6 +160,37 @@ pub struct StartCmd {
     #[clap(long, value_name = "URL")]
     pub execution_endpoint: Option<Url>,
 
+    /// The WebSocket URL of the execution engine. Used for subscribing to
+    /// real-time execution layer events (e.g. persisted block notifications).
+    ///
+    /// If omitted, derived from --eth-rpc-endpoint using the convention
+    /// (scheme http→ws / https→wss, port + 1).
+    ///
+    /// Example: ws://localhost:8546
+    #[clap(long, value_name = "URL")]
+    pub execution_ws_endpoint: Option<Url>,
+
+    /// Enable persistence backpressure during startup replay. When enabled,
+    /// the consensus layer waits for the execution layer to persist blocks
+    /// before replaying further.
+    ///
+    /// Requires --execution-ws-endpoint (RPC mode) or IPC mode.
+    #[clap(long = "execution-persistence-backpressure")]
+    pub execution_persistence_backpressure: bool,
+
+    /// Number of blocks the execution layer is allowed to lag behind the
+    /// consensus layer before persistence backpressure is applied.
+    ///
+    /// Only takes effect when --execution-persistence-backpressure is enabled.
+    /// Large values weaken backpressure and may allow the execution layer
+    /// to accumulate a significant unpersisted block buffer.
+    #[clap(
+        long = "execution-persistence-backpressure-threshold",
+        value_name = "BLOCKS",
+        default_value = "100"
+    )]
+    pub execution_persistence_backpressure_threshold: u64,
+
     /// The path to the JWT secret file shared by Malachite and the execution
     /// engine. This is a mandatory form of authentication which ensures that
     /// Malachite has the authority to control the execution engine.
@@ -368,6 +399,9 @@ impl Default for StartCmd {
             execution_socket: None,
             eth_rpc_endpoint: None,
             execution_endpoint: None,
+            execution_ws_endpoint: None,
+            execution_persistence_backpressure: false,
+            execution_persistence_backpressure_threshold: 100,
             execution_jwt: None,
             metrics: None,
             rpc_addr: None,

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -198,7 +198,7 @@ The execution layer is built on top of [Reth][reth], extending it with Arc-speci
 
 - **Custom Precompiles** - Native implementations for Arc-specific operations (native coin control, post-quantum signatures, system accounting)
 - **Custom EVM Configuration** - Specialized gas calculations and execution logic
-- **Transaction Pool Enhancements** - Denylist support and custom validation
+- **Transaction Pool Enhancements** - Custom validation
 - **Block Executor** - Optimized block execution with Arc-specific features
 
 For architectural details, see the [Architecture Guide](../../docs/ARCHITECTURE.md).

--- a/crates/quake/README.md
+++ b/crates/quake/README.md
@@ -28,6 +28,7 @@ __Table of contents__
     - [Quick start (local deployment)](#quick-start-local-deployment)
     - [Command workflow](#command-workflow)
     - [Basic commands](#basic-commands)
+    - [The `load` and `spam` commands](#the-load-and-spam-commands)
     - [The `perturb` command](#the-perturb-command)
       - [Disconnect](#disconnect)
       - [Kill](#kill)
@@ -327,6 +328,86 @@ flags as both commands, e.g. `--all` (from `clean`) and `--remote` (from `start`
 ./quake restart validator1 validator2
 ```
 If you want to restart just some nodes leaving the others running, use `quake perturb restart <nodes>`.
+
+### The `load` and `spam` commands
+
+Both commands send transaction load to a running testnet using the [spammer](../spammer/README.md).
+Transactions are dispatched over WebSocket JSON-RPC. They
+accept the same flags as the spammer and differ only in the adopted send mode:
+
+| Command | Send mode | Nonce handling | Error recovery | Best for |
+|---------|-----------|---------------|----------------|----------|
+| `load` | Backpressure | Advances only on acceptance | Re-queries nonce on rejection, skips after 3 consecutive failures | Correctness-sensitive workloads, reproducible tests |
+| `spam` | Fire-and-forget | Incremented optimistically | None (transactions may be lost) | Peak-throughput stress tests |
+
+**Backpressure mode** (`load`) waits for each JSON-RPC response for a transaction before submitting
+the next one. If a transaction is rejected the sender re-queries the
+node for the correct nonce and retries. This is slower but guarantees that every
+submitted transaction has a valid nonce and is accepted by RPC endpoint.
+
+**Fire-and-forget mode** (`spam`) pushes transactions into a 10,000-item
+buffered channel and dispatches them without waiting for responses. Nonces are
+incremented at generation time, so nonce gaps can occur when transactions are
+rejected. Use `--wait-response` (`-w`) to optionally wait for each response
+while still using optimistic nonces; expect multiple `nonce too low` errors to be produced.
+
+Both commands support blending transaction types with `--mix`:
+```bash
+# 1000 TPS of native transfers for 30 seconds (backpressure)
+./quake load -t 30 -r 1000 validator1
+
+# Same workload in fire-and-forget mode
+./quake spam -t 30 -r 1000 validator1
+
+# Mixed workload: 70% native transfers, 30% ERC-20
+./quake load -t 60 -r 500 --mix transfer=70,erc20=30 validator1
+
+# Gas-intensive workload with diverse guzzler functions
+./quake load -t 60 -r 200 --mix guzzler=100 \
+  --guzzler-fn-weights hash-loop=70@2000,storage-write=30@600 validator1
+
+# Fire-and-forget at high throughput, targeting all nodes
+./quake spam -t 120 -r 5000
+```
+
+Common flags (see `./quake load --help` for the full list):
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--rate` | `-r` | `1000` | Target TPS across all generators |
+| `--time` | `-t` | `0` | Max duration in seconds (0 = unlimited) |
+| `--num-txs` | `-n` | `0` | Max total transactions (0 = unlimited) |
+| `--num-generators` | `-g` | `1` | Parallel generators, each with its own account slice |
+| `--mix` | | `transfer=100` | Transaction type blend: `transfer`, `erc20`, `guzzler` |
+| `--tx-latency` | | `false` | Record submit-to-finalized latency to CSV |
+
+If no target nodes are specified, transactions are sent to all nodes.
+
+#### Latency tracking (`--tx-latency`)
+
+The `--tx-latency` flag measures end-to-end transaction latency: the wall-clock
+time between `eth_sendRawTransaction` submission and finalized block inclusion.
+See the [spammer README](../spammer/README.md#transaction-latency-tracking) for
+full details on the tracking architecture, CSV output format, and analysis tools.
+
+```bash
+./quake load -t 30 -r 1000 --tx-latency validator1
+./quake load -t 30 -r 1000 --tx-latency --csv-dir .quake/results validator1
+```
+
+**Recording behavior by mode:**
+
+- **Backpressure** (`load`): only transactions accepted by the node are tracked.
+  Rejected and transient errors are skipped.
+- **Fire-and-forget with `--wait-response`** (`spam -w`): same, only accepted
+  transactions.
+- **Fire-and-forget without `--wait-response`** (`spam`): all dispatched
+  transactions are tracked, including those later rejected by the node. These
+  unmatched entries remain in memory and are evicted after 5 minutes without
+  appearing in the CSV.
+
+Transactions that are never included in a block (dropped from mempool, rejected
+after submission) do not appear in the CSV.
 
 ### The `perturb` command
 Quake offers a number of perturbations that can be applied to nodes in the testnet.

--- a/crates/quake/README.md
+++ b/crates/quake/README.md
@@ -872,9 +872,9 @@ The following flags are applied to all nodes by default. They are defined in
 | Flag | Default Value | Description |
 |------|---------------|-------------|
 | `http.enable` | `true` | Enable the HTTP-RPC server |
-| `http.api` | `["admin", "net", "eth", "web3", "debug", "txpool", "trace"]` | APIs exposed over HTTP |
+| `http.api` | `["admin", "net", "eth", "web3", "debug", "txpool", "trace", "reth"]` | APIs exposed over HTTP |
 | `ws.enable` | `true` | Enable the WebSocket-RPC server |
-| `ws.api` | `["admin", "net", "eth", "web3", "debug", "txpool", "trace"]` | APIs exposed over WebSocket |
+| `ws.api` | `["admin", "net", "eth", "web3", "debug", "txpool", "trace", "reth"]` | APIs exposed over WebSocket |
 | `engine.persistence-threshold` | `0` | Persistence threshold for engine payloads |
 | `engine.memory-block-buffer-target` | `0` | Memory block buffer target |
 | `enable-arc-rpc` | `true` | Enable Arc-specific RPC methods |

--- a/crates/quake/scenarios/localdev.toml
+++ b/crates/quake/scenarios/localdev.toml
@@ -1,3 +1,7 @@
+# Enable persistence backpressure in CI to exercise the feature until it is
+# enabled by default.
+cl.config.execution.persistence_backpressure = true
+
 [nodes.validator1]
 [nodes.validator2]
 [nodes.validator3]

--- a/crates/quake/src/manifest.rs
+++ b/crates/quake/src/manifest.rs
@@ -87,7 +87,9 @@ const EL_DEFAULT_HTTP_ENABLE: bool = true;
 const EL_DEFAULT_LOG_LEVEL: &str = "debug";
 const EL_DEFAULT_RPC_TXFEECAP: u64 = 1000;
 const EL_DEFAULT_WS_ENABLE: bool = true;
-const EL_DEFAULT_RPC_API: &[&str] = &["admin", "net", "eth", "web3", "debug", "txpool", "trace"];
+const EL_DEFAULT_RPC_API: &[&str] = &[
+    "admin", "net", "eth", "web3", "debug", "txpool", "trace", "reth",
+];
 const EL_DEFAULT_ENABLE_ARC_RPC: bool = true;
 const EL_DEFAULT_ARC_DENYLIST_ENABLED: bool = true;
 
@@ -1593,7 +1595,7 @@ mod tests {
             .contains(&"--http.api=admin,debug".to_string()));
         // Default array is overridden
         // the default array is
-        // http.api = ["admin", "net", "eth", "web3", "debug", "txpool", "trace"]
+        // http.api = ["admin", "net", "eth", "web3", "debug", "txpool", "trace", "reth"]
         // so this check confirms that no flag contains both "eth" and "http.api".
         assert!(!manifest.nodes["validator1"]
             .el_cli_flags()

--- a/crates/quake/src/setup.rs
+++ b/crates/quake/src/setup.rs
@@ -562,6 +562,7 @@ fn generate_consensus_config(
         // Use single-threaded runtime for lower resource usage when running local devnet
         runtime: RuntimeConfig::SingleThreaded,
         prune: PruningConfig::default(),
+        execution: Default::default(),
         rpc: RpcConfig {
             enabled: true,
             // IPADDR_ANY because we need external access to it for testing.
@@ -795,6 +796,15 @@ pub(crate) fn generate_node_cli_flags(
                 "--signing.remote=http://{name}-signer-proxy:{REMOTE_SIGNER_PROXY_PORT}"
             ));
         }
+
+        // Add persistence backpressure flags.
+        if node.cl_config.execution.persistence_backpressure {
+            flags.push("--execution-persistence-backpressure".to_string());
+        }
+        flags.push(format!(
+            "--execution-persistence-backpressure-threshold={}",
+            node.cl_config.execution.persistence_backpressure_threshold
+        ));
 
         // Add pruning flags from explicit cl_config.prune values.
         let prune = &node.cl_config.prune;

--- a/crates/quake/src/setup.rs
+++ b/crates/quake/src/setup.rs
@@ -800,11 +800,11 @@ pub(crate) fn generate_node_cli_flags(
         // Add persistence backpressure flags.
         if node.cl_config.execution.persistence_backpressure {
             flags.push("--execution-persistence-backpressure".to_string());
+            flags.push(format!(
+                "--execution-persistence-backpressure-threshold={}",
+                node.cl_config.execution.persistence_backpressure_threshold
+            ));
         }
-        flags.push(format!(
-            "--execution-persistence-backpressure-threshold={}",
-            node.cl_config.execution.persistence_backpressure_threshold
-        ));
 
         // Add pruning flags from explicit cl_config.prune values.
         let prune = &node.cl_config.prune;

--- a/crates/quake/templates/local/compose.yaml.hbs
+++ b/crates/quake/templates/local/compose.yaml.hbs
@@ -138,6 +138,7 @@ services:
       {{#if ../rpc}}
       - "--eth-rpc-endpoint=http://{{execution.inner.name}}:8545"
       - "--execution-endpoint=http://{{execution.inner.name}}:8551"
+      - "--execution-ws-endpoint=ws://{{execution.inner.name}}:8546"
       - "--execution-jwt=/app/assets/jwtsecret"
       {{else}}
       - "--eth-socket=/sockets/reth.ipc"
@@ -279,6 +280,7 @@ services:
       {{#if ../rpc}}
       - "--eth-rpc-endpoint=http://{{execution.inner.name}}_u:8545"
       - "--execution-endpoint=http://{{execution.inner.name}}_u:8551"
+      - "--execution-ws-endpoint=ws://{{execution.inner.name}}_u:8546"
       - "--execution-jwt=/app/assets/jwtsecret"
       {{else}}
       - "--eth-socket=/sockets/reth.ipc"

--- a/crates/quake/templates/remote/compose-node.yaml.hbs
+++ b/crates/quake/templates/remote/compose-node.yaml.hbs
@@ -109,6 +109,7 @@ services:
       {{#if rpc}}
       - "--eth-rpc-endpoint=http://{{el_container_name}}:8545"
       - "--execution-endpoint=http://{{el_container_name}}:8551"
+      - "--execution-ws-endpoint=ws://{{el_container_name}}:8546"
       - "--execution-jwt=/assets/jwtsecret"
       {{else}}
       - "--eth-socket=/sockets/reth.ipc"

--- a/crates/snapshots/Cargo.toml
+++ b/crates/snapshots/Cargo.toml
@@ -21,7 +21,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 directories.workspace = true
 eyre.workspace = true
 lz4.workspace = true
-reqwest = { workspace = true, features = ["blocking", "json"] }
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls-native-roots"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tar.workspace = true

--- a/crates/spammer/README.md
+++ b/crates/spammer/README.md
@@ -5,6 +5,7 @@ Transaction load generator: create, sign, and send transactions to multiple node
 **Table of contents**
 
 - [Architecture overview](#architecture-overview)
+- [Operating modes](#operating-modes)
 - [CLI usage](#cli-usage)
   - [`spammer ws`](#spammer-ws)
   - [`spammer nodes`](#spammer-nodes)
@@ -174,6 +175,20 @@ graph LR
 **Result Tracker**:
 - Monitors RPC request outcomes and provides real-time statistics on successful
   and failed transactions, with updates printed every second.
+
+## Operating modes
+
+The spammer supports two send modes:
+
+| Mode | Nonce handling | Error recovery | Best for |
+|------|---------------|----------------|----------|
+| Backpressure (default) | Advances only on acceptance | Re-queries nonce on rejection, skips after 3 consecutive failures | Correctness-sensitive workloads |
+| Fire-and-forget | Incremented optimistically | None (transactions may be lost) | Peak-throughput stress tests |
+
+When invoked via Quake, these modes map to the `load` and `spam` commands
+respectively. See the [Quake README](../quake/README.md#the-load-and-spam-commands)
+for CLI usage.
+When the `spammer` is executed directly, the `--fire-and-forget` flag enables the Fire-and-forget mode.
 
 ## CLI usage
 

--- a/crates/spammer/src/generator.rs
+++ b/crates/spammer/src/generator.rs
@@ -39,7 +39,25 @@ use crate::erc20::TEST_TOKEN_ADDRESS;
 pub(crate) const TESTNET_CHAIN_ID: u64 = 1337;
 const GUZZLER_ADDRESS: Address = address!("1be052abb35D7f41609Bfec8F2fC2A684CB9984f");
 
-/// Generate transactions signed by a given account and send them to the Reth RPC endpoints in round-robin fashion.
+/// Generates and signs transactions from a pool of pre-funded genesis accounts.
+///
+/// Each generator is assigned a non-overlapping slice of the account space and
+/// cycles through its accounts in round-robin order. It supports three
+/// transaction types, selected per-transaction according to configurable
+/// weights ([`TxTypeMix`]):
+///
+/// - **Native transfers** -- simple value transfers between accounts.
+/// - **ERC-20 calls** -- `transfer`, `approve`, and `transferFrom` against
+///   a deployed `TestToken` contract, with function mix controlled by
+///   [`Erc20FnWeights`].
+/// - **GasGuzzler calls** -- gas-intensive operations (`hashLoop`,
+///   `storageWrite`, `storageRead`, `guzzle`, `guzzle2`) against a deployed
+///   `GasGuzzler` contract, with function mix controlled by
+///   [`GuzzlerFnWeights`].
+///
+/// In fire-and-forget mode the generator pushes signed transactions into a
+/// channel for a separate [`TxSender`](crate::sender::TxSender) task; in backpressure mode the sender
+/// owns the generator directly and calls [`next_tx`](Self::next_tx).
 pub(crate) struct TxGenerator {
     id: usize,
     signers: Vec<Option<LocalSigner<SigningKey>>>,

--- a/crates/spammer/src/sender.rs
+++ b/crates/spammer/src/sender.rs
@@ -14,6 +14,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Transaction sending with two operating modes.
+//!
+//! ## Backpressure mode (default)
+//!
+//! The sender owns a [`TxGenerator`] directly and drives it in a tight loop:
+//! generate a transaction, submit it via JSON-RPC, wait for the response, then
+//! advance the nonce only on acceptance. On rejection the sender re-queries the
+//! node for the correct nonce and retries. After three consecutive rejections
+//! for the same account it skips that account to avoid an infinite retry loop.
+//!
+//! Use backpressure mode for correctness-sensitive workloads where every
+//! transaction must land on-chain (e.g., contract deployments, nonce-dependent
+//! sequences, reproducible load tests).
+//!
+//! ## Fire-and-forget mode
+//!
+//! A separate generator task pushes signed transactions into a buffered channel
+//! (capacity 10,000). The sender reads from the channel and dispatches each
+//! transaction without waiting for the JSON-RPC response (unless
+//! `--wait-response` is set). Nonces are incremented optimistically at
+//! generation time, so nonce gaps can occur on rejection.
+//!
+//! Use fire-and-forget mode for peak-throughput stress tests where some
+//! transaction loss is acceptable.
+//!
+//! Both modes share the same rate limiter, round-robin node selection, and
+//! optional latency tracking.
+
 use alloy_consensus::{Signed, TxEip1559};
 use color_eyre::eyre::{self, Result, WrapErr};
 use serde_json::json;
@@ -57,9 +85,19 @@ pub(crate) enum TxSource {
     Backpressure(Box<TxGenerator>),
 }
 
-/// Transaction sender for one tx generator.
-/// Receive transactions from one tx generator and send them to multiple nodes in round-robin fashion.
-/// Report the result of each transaction to the result tracker.
+/// Dispatches signed transactions to one or more nodes over WebSocket JSON-RPC.
+///
+/// Each sender is paired with exactly one transaction source (a generator or a
+/// channel) and fans out transactions across the target nodes in round-robin
+/// order. Results are reported to a shared [`ResultTracker`] for aggregate
+/// statistics, and optionally to a [`LatencyTracker`] for submit-to-finalized
+/// latency measurement.
+///
+/// The sender's operating mode is determined by [`TxSource`]:
+/// - **Backpressure** ([`TxSource::Backpressure`]): owns the generator, waits
+///   for every JSON-RPC response, retries on rejection with nonce refresh.
+/// - **Fire-and-forget** ([`TxSource::Channel`]): reads from a buffered
+///   channel, sends without waiting (unless `wait_response` is set).
 pub(crate) struct TxSender {
     id: usize,
     /// WebSocket clients used to dispatch transactions to nodes in round-robin.

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -65,6 +65,9 @@ pub struct Config {
     /// RPC config
     pub rpc: RpcConfig,
 
+    /// Execution-layer config
+    pub execution: ExecutionConfig,
+
     /// Signing config
     pub signing: SigningConfig,
 }
@@ -163,6 +166,35 @@ impl Default for RpcConfig {
             listen_addr: format!("127.0.0.1:{RPC_BASE_PORT}")
                 .parse()
                 .expect("valid socket address"),
+        }
+    }
+}
+
+/// Execution-layer tuning parameters.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionConfig {
+    /// Whether persistence backpressure is enabled.
+    #[serde(default)]
+    pub persistence_backpressure: bool,
+
+    /// Number of blocks the EL is allowed to lag behind the CL before
+    /// persistence backpressure is applied during startup replay.
+    /// Only takes effect when `persistence_backpressure` is true.
+    #[serde(default = "ExecutionConfig::default_persistence_backpressure_threshold")]
+    pub persistence_backpressure_threshold: u64,
+}
+
+impl ExecutionConfig {
+    const fn default_persistence_backpressure_threshold() -> u64 {
+        100
+    }
+}
+
+impl Default for ExecutionConfig {
+    fn default() -> Self {
+        Self {
+            persistence_backpressure: false,
+            persistence_backpressure_threshold: Self::default_persistence_backpressure_threshold(),
         }
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,9 +5,12 @@ This document provides a comprehensive overview of the Arc Network node architec
 ## Table of Contents
 
 - [Overview](#overview)
-- [Core Crates](#core-crates)
-- [Node Crate Deep Dive](#node-crate-deep-dive)
-- [Extension Points](#extension-points)
+- [Architectural Layers](#architectural-layers)
+- [Transaction Lifecycle](#transaction-lifecycle)
+- [Block Production Flow](#block-production-flow)
+- [Synchronization Modes](#synchronization-modes)
+- [Execution Layer Deep Dive](#execution-layer-deep-dive)
+- [Data Flow](#data-flow)
 
 ## Overview
 
@@ -91,7 +94,7 @@ sequenceDiagram
 
     User->>RPC: eth_sendRawTransaction
     RPC->>TxPool: Add transaction
-    Note over TxPool: Validation, gas checks,<br/>denylist filtering
+    Note over TxPool: Validation, gas checks
 
     Consensus->>Engine: Request payload<br/>(getPayload)
     Engine->>TxPool: Select transactions
@@ -112,9 +115,8 @@ sequenceDiagram
 
 ### Key Stages
 
-1. **Transaction Submission** ([crates/node/src/txpool/pool.rs](../crates/node/src/txpool/pool.rs))
+1. **Transaction Submission** ([crates/execution-txpool/src/pool.rs](../crates/execution-txpool/src/pool.rs))
    - Validates transaction format and signature
-   - Checks denylist for blocked addresses
    - Adds to mempool if valid
 
 2. **Block Proposal** ([crates/malachite-app/src/app.rs](../crates/malachite-app/src/app.rs))
@@ -127,7 +129,7 @@ sequenceDiagram
    - Once ⅔+ votes collected, block is decided
    - Certificate generated with validator signatures
 
-4. **Execution** ([crates/node/src/executor.rs](../crates/node/src/executor.rs))
+4. **Execution** ([crates/evm/src/executor.rs](../crates/evm/src/executor.rs))
    - Consensus sends `engine_newPayload` + `engine_forkchoiceUpdated`
    - Block executor runs transactions through EVM
    - State trie updated with new balances, storage
@@ -177,7 +179,7 @@ Traditional gossip-based synchronization where nodes:
 - Participate in consensus as validators or full nodes
 - Maintain peer connections for liveness
 
-**Implementation**: [crates/malachite-app/src/node.rs](../crates/malachite-app/src/node.rs) (lines 340-380)
+**Implementation**: [crates/malachite-app/src/node.rs](../crates/malachite-app/src/node.rs)
 
 ### RPC Sync Mode
 Alternative for lightweight full nodes that:
@@ -210,49 +212,43 @@ graph TB
     style N3 fill:#e1f5ff
 ```
 
-## Node Crate Deep Dive
+## Execution Layer Deep Dive
 
-The `node/` crate is the heart of the execution layer. Here's a detailed breakdown:
+The execution layer is split across several dedicated crates. Here's a breakdown:
 
 ### EVM Customization
 
-The EVM layer (`src/evm.rs`) allows for:
+The EVM layer ([crates/evm/src/evm.rs](../crates/evm/src/evm.rs)) allows for:
 
 - Custom base fee calculation logic
 - Integration of custom precompiles
 - EVM configuration overrides
 
-See [Configuration Guide](CONFIGURATION.md#custom-base-fee-calculation) for customization details.
-
 ### Precompiles
 
-Custom precompiles are defined in `src/precompiles/`:
+Custom precompiles are defined in [crates/precompiles/src/](../crates/precompiles/src/):
 
-- **Native Coin Authority** (`0x80`) - Authority operations for native coin
-- **Native Coin Control** (`0x81`) - Control operations for native coin
-- **System Accounting** (`0x82`) - System-level accounting operations
-- **PQ Signature Verify** (`0x83`) - Post-quantum signature verification
-
-See [Configuration Guide](CONFIGURATION.md#adding-more-precompiles) for details on adding new precompiles.
+- **Native Coin Authority** (`0x1800..0000`) - Mint, burn, transfer operations for native coin
+- **Native Coin Control** (`0x1800..0001`) - Address blocklist
+- **System Accounting** (`0x1800..0002`) - Gas fee ring buffer
+- **Call From** (`0x1800..0003`) - Plumbing to support native batch and memo txns.
+- **PQ Signature Verify** (`0x1800..0004`) - Post-quantum SLH-DSA-SHA2-128s verification
 
 ### Transaction Pool
 
-The custom transaction pool (`src/txpool/`) provides:
+The custom transaction pool ([crates/execution-txpool/src/](../crates/execution-txpool/src/)) provides:
 
 - Configurable pool parameters
 - Custom validation logic
-- Transaction denylist support
-
-See [Configuration Guide](CONFIGURATION.md#transaction-denylist-configuration) for details.
 
 ### Payload Building
 
-The payload builder (`src/payload.rs`) handles:
+The payload builder ([crates/execution-payload/src/payload.rs](../crates/execution-payload/src/payload.rs)) handles:
 
 - Block construction
 - Transaction selection and ordering
 - Gas limit management
-- Emergency denylist on panic
+- Adds to the InvalidTxList during execution panics
 
 ## Data Flow
 
@@ -261,15 +257,13 @@ graph LR
     TxSubmit[Transaction Submitted]
     TxPool[Transaction Pool]
     Validator[Pool Validator]
-    Denylist[Denylist Check]
     Payload[Payload Builder]
     Executor[Block Executor]
     EVM[EVM Execution]
     State[State Update]
 
     TxSubmit --> Validator
-    Validator --> Denylist
-    Denylist --> TxPool
+    Validator --> TxPool
     TxPool --> Payload
     Payload --> Executor
     Executor --> EVM
@@ -278,6 +272,5 @@ graph LR
 
 ## Further Reading
 
-- [Configuration Guide](CONFIGURATION.md) - Detailed configuration options
 - [Contributing Guide](../CONTRIBUTING.md) - Development workflow and guidelines
 - [ADRs](adr/README.md) - Architecture Decision Records

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,6 @@ If a decision affects multiple components or has lasting implications, it likely
 | ADR | Title | Status | Date       |
 |-----|-------|--------|------------|
 | [0001](0001-adr-process.md) | ADR Process | Proposed | 2025-12-11 |
+| [0002](0002-block-dissemination-protocol.md) | Block Dissemination Protocol | Draft | 2026-01-13 |
+| [0003](0003-governance-configuration-and-validation.md) | Dynamic Block Gas Limit Configuration Validation | Draft | 2026-02-20 |
+| [0004](0004-base-fee-validation.md) | Base Fee Parameter Validation | Draft | 2026-03-03 |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,12 @@ Versions across networks may not be compatible. Consult the table below to confi
 curl -L https://raw.githubusercontent.com/circlefin/arc-node/main/arcup/install | bash
 ```
 
+After installing, restart your shell or run:
+
+```sh
+source ~/.arc/env
+```
+
 Verify the installation:
 
 ```sh

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -21,9 +21,11 @@ mkdir -p ~/.arc/execution ~/.arc/consensus
 sudo install -d -o $USER /run/arc
 ```
 
+> **macOS:** `/run` does not exist on macOS. Use a user-local directory instead (e.g. `mkdir -p ~/.arc/run`) and adjust the `--ipcpath`, `--auth-ipc.path`, `--eth-socket`, and `--execution-socket` flags in the commands below accordingly.
+
 When running as a systemd service, `RuntimeDirectory=arc` creates `/run/arc` automatically — skip the second command.
 
-**1. Download snapshots** (recommended for faster initial sync). This lets your node start from a recent block height rather than syncing from genesis.
+**1. Download snapshots** (required). Syncing from genesis is not currently supported -- a snapshot is needed to bootstrap the node.
 
 ```sh
 arc-snapshots download --chain=arc-testnet
@@ -83,6 +85,20 @@ arc-node-consensus start \
 
 > **Note:** Start the Execution Layer first. The Consensus Layer connects to it on startup and will fail if the EL is not running.
 
+> **Note:** The Blockdaemon endpoint does not currently support WebSocket connections. The node will log retry warnings for this endpoint but still syncs correctly via the other two endpoints. HTTP block fetching from Blockdaemon works normally.
+
+**5. Verify the node is syncing:**
+
+Wait about 30 seconds, then check the block height:
+
+```sh
+curl -s -X POST http://localhost:8545 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+```
+
+The `result` field should be a hex block number that increases over time. If it stays at `0x0`, check the Consensus Layer logs for connection errors.
+
 ### EL ↔ CL Communication
 
 The Quick Start above uses IPC sockets, which require EL and CL to run on the same host. If they are on separate hosts, use RPC instead.
@@ -138,6 +154,8 @@ Check out [reth system requirements](https://reth.rs/run/system-requirements/) f
 ### Production Deployment
 
 For production, run both processes as systemd services.
+
+> **Note:** The service files below use `$USER` and `$HOME`, which the shell expands to your current username and home directory before writing the file. Review the generated file with `sudo cat /etc/systemd/system/arc-execution.service` after creation to confirm the paths are correct.
 
 #### Execution Layer Service
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -806,16 +806,6 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2114,6 +2104,16 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2592,16 +2592,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -3034,9 +3024,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3570,9 +3560,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3901,9 +3891,9 @@
       }
     },
     "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -4068,9 +4058,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4464,9 +4454,9 @@
       }
     },
     "node_modules/globby/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4690,6 +4680,17 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/hardhat-gas-reporter/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/hardhat-gas-reporter/node_modules/ethereum-cryptography": {
@@ -5066,9 +5067,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5506,9 +5507,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5779,6 +5780,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -6040,9 +6051,9 @@
       }
     },
     "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -6081,16 +6092,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ox": {
@@ -6528,6 +6529,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -6605,9 +6607,9 @@
       }
     },
     "node_modules/recursive-readdir/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6813,9 +6815,9 @@
       }
     },
     "node_modules/sc-istanbul/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6964,13 +6966,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -7087,9 +7089,9 @@
       }
     },
     "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7663,16 +7665,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-buffer": {
@@ -7907,16 +7906,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -8494,13 +8490,13 @@
       "requires": {
         "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "3"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8513,7 +8509,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         }
       }
@@ -8546,7 +8542,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "minimatch": "3",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -8563,9 +8559,9 @@
           }
         },
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8584,7 +8580,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         }
       }
@@ -8906,12 +8902,6 @@
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
       }
-    },
-    "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -9239,7 +9229,7 @@
         "picocolors": "^1.1.0",
         "semver": "^6.3.0",
         "table": "^6.8.0",
-        "undici": "^5.14.0"
+        "undici": "6.24.1"
       }
     },
     "@nomicfoundation/hardhat-viem": {
@@ -9266,7 +9256,7 @@
         "ethers": "^6.14.0",
         "fs-extra": "^10.0.0",
         "immer": "10.0.2",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "ndjson": "2.0.0"
       },
       "dependencies": {
@@ -9509,7 +9499,7 @@
         "@sentry/tracing": "5.30.0",
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
-        "cookie": "^0.4.1",
+        "cookie": "0.7.0",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
@@ -9795,18 +9785,27 @@
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
+        "minimatch": "9",
         "semver": "^7.6.0",
         "ts-api-utils": "^2.1.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "minimatch": {
           "version": "9.0.9",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
           "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "2.0.3"
           }
         },
         "semver": {
@@ -10114,15 +10113,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
       }
     },
     "braces": {
@@ -10439,9 +10429,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
       "dev": true
     },
     "create-hash": {
@@ -10623,7 +10613,7 @@
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.11.9",
+        "bn.js": "4.12.3",
         "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
         "hmac-drbg": "^1.0.1",
@@ -10763,7 +10753,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "3",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -10781,9 +10771,9 @@
           }
         },
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -10821,7 +10811,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         },
         "optionator": {
@@ -11048,14 +11038,14 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.12.3",
         "number-to-bn": "1.7.0"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+          "version": "4.12.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+          "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
           "dev": true,
           "peer": true
         }
@@ -11171,14 +11161,14 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "requires": {
-        "flatted": "^3.2.9",
+        "flatted": "3.4.2",
         "keyv": "^4.5.4"
       }
     },
     "flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "follow-redirects": {
@@ -11387,7 +11377,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^5.0.1",
+        "minimatch": "5",
         "once": "^1.3.0"
       }
     },
@@ -11446,9 +11436,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -11466,7 +11456,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "3",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -11478,7 +11468,7 @@
           "dev": true,
           "peer": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         }
       }
@@ -11549,11 +11539,11 @@
         "find-up": "^5.0.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "immutable": "^4.0.0-rc.12",
+        "immutable": "4.3.8",
         "io-ts": "1.10.4",
         "json-stream-stringify": "^3.1.4",
         "keccak": "^3.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micro-eth-signer": "^0.14.0",
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
@@ -11567,7 +11557,7 @@
         "stacktrace-parser": "^0.1.10",
         "tinyglobby": "^0.2.6",
         "tsort": "0.0.1",
-        "undici": "^5.14.0",
+        "undici": "6.24.1",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -11670,7 +11660,7 @@
         "ethereum-cryptography": "^2.1.3",
         "glob": "^10.3.10",
         "jsonschema": "^1.4.1",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "markdown-table": "2.0.0",
         "sha1": "^1.1.1",
         "viem": "^2.27.0"
@@ -11692,6 +11682,16 @@
           "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
           "dev": true,
           "peer": true
+        },
+        "brace-expansion": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
         },
         "ethereum-cryptography": {
           "version": "2.2.1",
@@ -11715,7 +11715,7 @@
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^3.1.2",
-            "minimatch": "^9.0.4",
+            "minimatch": "9",
             "minipass": "^7.1.2",
             "package-json-from-dist": "^1.0.0",
             "path-scurry": "^1.11.1"
@@ -11728,7 +11728,7 @@
           "dev": true,
           "peer": true,
           "requires": {
-            "brace-expansion": "^2.0.2"
+            "brace-expansion": "2.0.3"
           }
         }
       }
@@ -11868,9 +11868,9 @@
       "peer": true
     },
     "immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true
     },
     "import-fresh": {
@@ -12164,9 +12164,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -12365,7 +12365,17 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "1.1.13"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
     },
     "minimist": {
@@ -12418,9 +12428,9 @@
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "5",
         "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -12511,7 +12521,7 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-gyp-build": {
@@ -12550,14 +12560,14 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "bn.js": "4.11.6",
+        "bn.js": "4.12.3",
         "strip-hex-prefix": "1.0.0"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+          "version": "4.12.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+          "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
           "dev": true,
           "peer": true
         }
@@ -12592,12 +12602,6 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true
     },
     "ox": {
       "version": "0.8.1",
@@ -12878,6 +12882,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -12928,13 +12933,13 @@
       "dev": true,
       "peer": true,
       "requires": {
-        "minimatch": "^3.0.5"
+        "minimatch": "3"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -12949,7 +12954,7 @@
           "dev": true,
           "peer": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         }
       }
@@ -13071,9 +13076,9 @@
           }
         },
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -13090,7 +13095,7 @@
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "2 || 3",
+            "minimatch": "3",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -13129,7 +13134,7 @@
           "dev": true,
           "peer": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         },
         "resolve": {
@@ -13186,13 +13191,10 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -13273,9 +13275,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -13293,7 +13295,7 @@
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.1.1",
+            "minimatch": "3",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -13305,7 +13307,7 @@
           "dev": true,
           "peer": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.13"
           }
         }
       }
@@ -13355,7 +13357,7 @@
         "js-sha3": "0.8.0",
         "memorystream": "^0.3.1",
         "semver": "^5.5.0",
-        "tmp": "0.0.33"
+        "tmp": "0.2.5"
       },
       "dependencies": {
         "semver": {
@@ -13383,7 +13385,7 @@
         "global-modules": "^2.0.0",
         "globby": "^10.0.1",
         "jsonschema": "^1.2.4",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mocha": "^10.2.0",
         "node-emoji": "^1.10.0",
         "pify": "^4.0.1",
@@ -13690,13 +13692,10 @@
       }
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true
     },
     "to-buffer": {
       "version": "1.2.1",
@@ -13839,13 +13838,10 @@
       "peer": true
     },
     "undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
-      }
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "dev": true
     },
     "undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,25 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "overrides": {
+    "bn.js@<4.12.3": "4.12.3",
+    "cookie": "0.7.0",
+    "flatted": "3.4.2",
+    "immutable": "4.3.8",
+    "lodash": "4.18.1",
+    "minimatch@3": {
+      "brace-expansion": "1.1.13"
+    },
+    "minimatch@5": {
+      "brace-expansion": "2.0.3"
+    },
+    "minimatch@9": {
+      "brace-expansion": "2.0.3"
+    },
+    "serialize-javascript": "7.0.5",
+    "tmp": "0.2.5",
+    "undici": "6.24.1"
+  },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@noble/ed25519": "^2.3.0",


### PR DESCRIPTION
  ## Summary
  
  - Add `rustls-tls-native-roots` to snapshot download reqwest features (fixes TLS on platforms without bundled certs)
  - Document spammer backpressure and fire-and-forget operating modes in spammer + quake READMEs
  - Refresh `docs/ARCHITECTURE.md` with current crate paths, precompile addresses, remove stale denylist references
  - Add ADR 0002-0004 entries to `docs/adr/README.md`
  - Add testnet/alpha software disclaimer to root `README.md`
  - Add persistence latency tracking module to eth-engine
  - Extend consensus ready handler with validator set management
  - Fix follow endpoint URL handling
  - Add new CLI config options for consensus tuning
  - Update quake localdev scenarios and compose templates
  - Update node docs and dependency versions
 