### PR TITLE
chore: update cloudsmith namespace to circle/arc-network

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   REGISTRY: docker.cloudsmith.io
-  REGISTRY_NAMESPACE: circle/arc
+  REGISTRY_NAMESPACE: circle/arc-network
 
 jobs:
   build:


### PR DESCRIPTION
Update REGISTRY_NAMESPACE from circle/arc to circle/arc-network in build-docker.yaml
