### PR TITLE
ci: target main in workflows and tooling

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [labeled, synchronize]
     branches:
-      - master
+      - main
       - release/*
   push:
     tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Public CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ QUAKE := cargo run --bin quake --
 LOAD_PREDEFINED_ARC_REMOTE_SIGNER_KEYS := true
 DEFAULT_BRANCH ?= $(shell git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
 ifeq ($(DEFAULT_BRANCH),)
-DEFAULT_BRANCH = master
+DEFAULT_BRANCH = main
 endif
 
 ##@ Help


### PR DESCRIPTION
## Summary

- update Public CI to run on `main` instead of `master`
- update the Docker workflow PR trigger to target `main`
- update the `Makefile` fallback branch for `buf-breaking` to `main`

## Verification

- confirmed the repository default branch is `main`
- checked the touched workflow/tooling files for remaining `master` references
- ran `make -n buf-breaking` and verified it now targets `.git#branch=main`
- ran `git diff --check`