### PR TITLE
Fix #15: Add missing /sockets volume mount to deployments

### DIFF
--- a/deployments/arc_execution.yaml
+++ b/deployments/arc_execution.yaml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ../assets/localdev:/app/assets
       - ./entrypoint_arc_execution.sh:/usr/local/bin/entrypoint.sh
-            - ./sockets:/sockets
+      - ./sockets:/sockets
     extra_hosts:
       - host.docker.internal:host-gateway
     ports:

--- a/deployments/arc_execution.yaml
+++ b/deployments/arc_execution.yaml
@@ -27,6 +27,7 @@ services:
     volumes:
       - ../assets/localdev:/app/assets
       - ./entrypoint_arc_execution.sh:/usr/local/bin/entrypoint.sh
+            - ./sockets:/sockets
     extra_hosts:
       - host.docker.internal:host-gateway
     ports:


### PR DESCRIPTION
Fixes #15

## Problem

When running the node with `docker-compose -f arc_execution.yaml -f arc_consensus.yaml up -d`, the execution engine crashes on startup:

\`\`\`
Error: failed to listen on ipc endpoint '/sockets/reth.ipc': No such file or directory
\`\`\`

The command section already references `--ipcpath=/sockets/reth.ipc` and `--auth-ipc.path=/sockets/auth.ipc`, but there's no corresponding volume mount for `/sockets` in the compose file so the directory doesn't exist inside the container.

## Fix

Added `./sockets:/sockets` to the volumes section of the `arc_execution` service.

## Testing

After adding the mount and creating the local `sockets/` directory, both `arc_execution` and `arc_consensus` containers boot and sync correctly.