### PR TITLE
tests: remove duplicate NativeFiatToken blocklist case

### DIFF
--- a/tests/localdev/NativeFiatToken.test.ts
+++ b/tests/localdev/NativeFiatToken.test.ts
@@ -936,17 +936,6 @@ describe('NativeFiatToken', () => {
 
       // Blocklist the predicted contract address
       await USDC.attach(operator).write.blacklist([predictedAddress]).then(ReceiptVerifier.waitSuccess)
-    })
-
-    it('execution frames blocklist: CREATE from EOA succeeds when created address is blocklisted and no value is transferred', async () => {
-      const { client, operator, sender } = await clients()
-
-      // Calculate the address that will be created
-      const nonce = await client.getTransactionCount({ address: sender.account.address })
-      const predictedAddress = getCreateAddress({ from: sender.account.address, nonce: BigInt(nonce) })
-
-      // Blocklist the predicted contract address
-      await USDC.attach(operator).write.blacklist([predictedAddress]).then(ReceiptVerifier.waitSuccess)
 
       // Verify the predicted address is blocklisted
       const isBlocklisted = await NativeCoinControl.isBlocklisted(client, predictedAddress)


### PR DESCRIPTION
## Summary
- remove the duplicate `NativeFiatToken` blocklist test case
- keep the complete version of the test and drop the incomplete stub with no assertions or cleanup

## Verification
- confirmed the duplicate test title appears only once in `tests/localdev/NativeFiatToken.test.ts`
- ran `git diff --check`

## Context
This restores the change from #38, which was unexpectedly auto-closed after the target branch was updated.
