### PR TITLE
arcup: error when --install is missing a version

### DIFF
--- a/arcup/arcup
+++ b/arcup/arcup
@@ -181,6 +181,9 @@ while [[ $# -gt 0 ]]; do
             version
             ;;
         -i|--install)
+            if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                error "--install requires a version argument (for example: arcup --install v1.0.0)"
+            fi
             VERSION="$2"
             shift 2
             ;;


### PR DESCRIPTION
## Summary
- validate `--install` before reading the next argument
- print a clear error when the version is missing or when the next token is another flag

## Verification
- `bash arcup/arcup -i`
- `bash arcup/arcup --help`

## Context
This restores the change from #37, which was unexpectedly auto-closed after the target branch was updated.
