### PR TITLE
fix(quake): prepare local service volume dirs

### DIFF
--- a/crates/quake/src/setup.rs
+++ b/crates/quake/src/setup.rs
@@ -344,9 +344,23 @@ pub(crate) fn generate_jwt_secret(testnet_dir: &Path, force: bool) -> Result<()>
 /// can write to mounted volumes. Required on Linux where bind-mount permissions are strict.
 pub(crate) fn set_local_testnet_directory_permissions(
     testnet_dir: &Path,
+    monitoring_dir: &Path,
     node_names: &[String],
 ) -> Result<()> {
     let logs_dir = testnet_dir.join("logs");
+    let writable_dirs = [
+        logs_dir.clone(),
+        monitoring_dir.join("data").join("grafana"),
+        monitoring_dir.join("data").join("prometheus"),
+        testnet_dir.join("blockscout").join("logs"),
+        testnet_dir.join("blockscout").join("dets"),
+    ];
+
+    for dir in &writable_dirs {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create directory: {}", dir.display()))?;
+    }
+
     for name in node_names {
         let reth_dir = testnet_dir.join(name).join("reth");
         fs::create_dir_all(&reth_dir)
@@ -358,8 +372,6 @@ pub(crate) fn set_local_testnet_directory_permissions(
     #[cfg(unix)]
     {
         let perms = fs::Permissions::from_mode(0o777);
-        fs::set_permissions(&logs_dir, perms.clone())
-            .with_context(|| format!("Failed to set permissions on {}", logs_dir.display()))?;
         for name in node_names {
             let node_dir = testnet_dir.join(name);
             if node_dir.exists() {
@@ -373,6 +385,10 @@ pub(crate) fn set_local_testnet_directory_permissions(
                     format!("Failed to set permissions on {}", sockets_dir.display())
                 })?;
             }
+        }
+        for dir in &writable_dirs {
+            fs::set_permissions(dir, perms.clone())
+                .with_context(|| format!("Failed to set permissions on {}", dir.display()))?;
         }
     }
     Ok(())
@@ -1235,6 +1251,28 @@ mod tests {
             actual, expected,
             "{node}: expected {expected} peers, got {actual}"
         );
+    }
+
+    #[test]
+    fn local_testnet_directory_permissions_create_service_volume_dirs() {
+        let dir = tempdir().unwrap();
+        let testnet_dir = dir.path().join("localdev");
+        let monitoring_dir = dir.path().join("monitoring");
+        let node_names = vec!["validator1".to_string()];
+
+        set_local_testnet_directory_permissions(&testnet_dir, &monitoring_dir, &node_names)
+            .unwrap();
+
+        for path in [
+            monitoring_dir.join("data").join("grafana"),
+            monitoring_dir.join("data").join("prometheus"),
+            testnet_dir.join("blockscout").join("logs"),
+            testnet_dir.join("blockscout").join("dets"),
+            testnet_dir.join("validator1").join("reth"),
+            testnet_dir.join("validator1").join("sockets"),
+        ] {
+            assert!(path.is_dir(), "expected {} to exist", path.display());
+        }
     }
 
     #[test]

--- a/crates/quake/src/testnet.rs
+++ b/crates/quake/src/testnet.rs
@@ -511,7 +511,12 @@ impl Testnet {
         // For local testnets, create EL reth dirs and set permissions so containers (user arc) can write
         if self.infra_data.infra_type == InfraType::Local {
             let node_names: Vec<String> = self.manifest.nodes.keys().cloned().collect();
-            setup::set_local_testnet_directory_permissions(&self.dir, &node_names)?;
+            let monitoring_dir = self.quake_dir.join("monitoring");
+            setup::set_local_testnet_directory_permissions(
+                &self.dir,
+                &monitoring_dir,
+                &node_names,
+            )?;
         }
 
         // In remote mode, provision the Control Center server


### PR DESCRIPTION
## Summary

- pre-create local monitoring data directories for Grafana and Prometheus during Quake setup
- pre-create local Blockscout logs/dets bind mount directories during Quake setup
- apply the existing local writable-directory permission handling to those service volume paths
- add a unit test covering the generated local service volume directories

Fixes #32

## Testing

- `cargo +1.93 fmt --check`

I also tried `cargo +1.93 check -p quake --bin quake`, but this Windows environment is missing `libclang` for `reth-mdbx-sys`, so the build stops before checking the `quake` target.