### PR TITLE
fix(batch): use blockhash(block.number - 1) in _tryBlockAndAggregate

### DIFF
--- a/contracts/src/batch/Multicall3From.sol
+++ b/contracts/src/batch/Multicall3From.sol
@@ -163,7 +163,7 @@ contract Multicall3From is IMulticall3From {
         returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
     {
         blockNumber = block.number;
-        blockHash = blockhash(block.number);
+        blockHash = blockhash(block.number - 1);
         uint256 length = calls.length;
         returnData = new Result[](length);
         for (uint256 i = 0; i < length;) {

--- a/contracts/test/batch/Multicall3From.t.sol
+++ b/contracts/test/batch/Multicall3From.t.sol
@@ -340,7 +340,7 @@ contract Multicall3FromTest is Test {
             multicall.blockAndAggregate(calls);
 
         assertEq(blockNumber, block.number);
-        assertEq(blockHash, blockhash(block.number));
+        assertEq(blockHash, blockhash(block.number - 1));
         assertEq(results.length, 1);
         assertTrue(results[0].success);
         assertEq(target.value(), 33);
@@ -370,7 +370,7 @@ contract Multicall3FromTest is Test {
             multicall.tryBlockAndAggregate(false, calls);
 
         assertEq(blockNumber, block.number);
-        assertEq(blockHash, blockhash(block.number));
+        assertEq(blockHash, blockhash(block.number - 1));
         assertEq(results.length, 1);
         assertFalse(results[0].success);
     }


### PR DESCRIPTION
## Summary

`_tryBlockAndAggregate` was calling `blockhash(block.number)`, which
always returns `bytes32(0)` on mainnet EVM — the current block's hash
is not yet available during execution.

The correct value is `blockhash(block.number - 1)`, consistent with
the existing `getLastBlockHash()` implementation in the same contract.

## Root Cause

`blockhash(N)` returns `0` when `N >= block.number`. The existing tests
passed only because Foundry's test environment populates block hashes
differently from production EVM.

## Fix

- `Multicall3From._tryBlockAndAggregate`: `block.number` → `block.number - 1`
- Updated tests to assert the correct value

## Testing

forge test --match-path contracts/test/batch/Multicall3From.t.sol

29 tests passed, 0 failed.