### PR TITLE
docs: clean up README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ git config fetch.recurseSubmodules on-demand
 - [Yarn](https://yarnpkg.com/)
 - [Buf](https://github.com/bufbuild/buf)
 
-Install required tools on MacOS with Homebrew:
+Install required tools on macOS with Homebrew:
 
 ```bash
 brew install protobuf node yarn bufbuild/buf/buf
@@ -133,7 +133,7 @@ make test-all
 Generate and view test coverage (requires [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#installation)):
 
 ```bash
-# Install cargo-llvm-cov on MacOS with Homebrew (one-time setup)
+# Install cargo-llvm-cov on macOS with Homebrew (one-time setup)
 brew install cargo-llvm-cov
 
 # Generate coverage for unit tests
@@ -194,23 +194,22 @@ For more details, see our [Contributing Guide](CONTRIBUTING.md).
 - [Local Documentation](docs/) - Implementation guides and references
 
 ## Acknowledgements
-arc-node is open-source software, licensed under Apache 2.0, built from a number of open source libraries, and inspired by others. We would like to highlight several of them in particular and credit the teams that develop and maintain them.
+This project is open-source software licensed under Apache 2.0. It is built from a number of open source libraries and inspired by others. We would like to highlight several of them in particular and credit the teams that develop and maintain them.
 
-[Malachite](https://github.com/circlefin/malachite) -  Malachite, a flexible BFT consensus engine written in Rust, was originally developed at [Informal Systems](https://github.com/informalsystems) and [is now maintained by Circle](https://www.circle.com/blog/introducing-arc-an-open-layer-1-blockchain-purpose-built-for-stablecoin-finance) as part of Arc. We thank Informal Systems for originating and stewarding Malachite, and their continued contributions to the project.  
+[Malachite](https://github.com/circlefin/malachite) - Malachite, a flexible BFT consensus engine written in Rust, was originally developed at [Informal Systems](https://github.com/informalsystems) and [is now maintained by Circle](https://www.circle.com/blog/introducing-arc-an-open-layer-1-blockchain-purpose-built-for-stablecoin-finance) as part of Arc. We thank Informal Systems for originating and stewarding Malachite, and for their continued contributions to the project.
 
-[Reth / Paradigm](https://github.com/paradigmxyz/reth) - Reth is an EVM execution client that is used in Arc’s execution layer via Reth SDK. We thank the Paradigm team for continuing to push the envelope with Reth and their continued emphasis on performance, extensibility, and customization, as well as their commitment to open source. Additionally, we’re big fans of the Foundry toolchain as well! 
+[Reth / Paradigm](https://github.com/paradigmxyz/reth) - Reth is an EVM execution client that is used in Arc’s execution layer via the Reth SDK. We thank the Paradigm team for continuing to push the envelope with Reth and for their continued emphasis on performance, extensibility, and customization, as well as their commitment to open source. Additionally, we’re big fans of the Foundry toolchain as well!
 
 [libp2p](https://github.com/libp2p/rust-libp2p) - libp2p is used extensively through the arc-node consensus layer, and we thank the team for their development of it.
 
-[Tokio](https://github.com/tokio-rs/tokio) - Tokio is used extensively throughout the consensus and execution layers, and we are grateful to  the team for their continued development and maintenance of it.
+[Tokio](https://github.com/tokio-rs/tokio) - Tokio is used extensively throughout the consensus and execution layers, and we are grateful to the team for their continued development and maintenance of it.
 
-[Celo](https://celo.org/) -  USDC is the native token on Arc and supports interacting with it through an ERC-20 interface; this “linked interface” design was first (as far as we know) pioneered on Celo, and we’d like to credit the team for devising it.
+[Celo](https://celo.org/) - USDC is the native token on Arc and supports interacting with it through an ERC-20 interface; this “linked interface” design was first (as far as we know) pioneered on Celo, and we’d like to credit the team for devising it.
 
-[Alloy-rs](https://github.com/alloy-rs/alloy) - Alloy is used throughout the consensus and execution layers, and we are very thankful  to the team for this excellent library.
+[Alloy-rs](https://github.com/alloy-rs/alloy) - Alloy is used throughout the consensus and execution layers, and we are very thankful to the team for this excellent library.
 
 [Revm](https://github.com/bluealloy/revm) - Revm is used via the Reth SDK in the execution layer as the core EVM implementation. We thank the team for their continued development and maintenance of it.
 
-[Hardhat / Nomic Foundation](https://github.com/NomicFoundation/hardhat) - we thank the team for their continued development of the Hardhat toolchain. 
+[Hardhat / Nomic Foundation](https://github.com/NomicFoundation/hardhat) - We thank the team for their continued development of the Hardhat toolchain.
 
-[Viem](https://github.com/wevm/viem) - we thank the team for their continued development of Viem and other libraries.
-
+[Viem](https://github.com/wevm/viem) - We thank the team for their continued development of Viem and other libraries.


### PR DESCRIPTION
## Summary

- update macOS casing in the README setup and coverage instructions
- clean up wording and spacing in the acknowledgements section
- keep the change scoped to README.md to avoid conflicts with open docs PR #43

## Validation

- git diff --check