### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/crates/malachite-app/src/state.rs
+++ b/crates/malachite-app/src/state.rs
@@ -79,7 +79,7 @@ impl NextHeightInfo {
 /// such as whether to start the next height or restart the current height.
 #[derive(Debug)]
 pub enum Decision {
-    /// Decision was sucessfully committed, and we have the information needed to start the next height.
+    /// Decision was successfully committed, and we have the information needed to start the next height.
     Success(Box<NextHeightInfo>),
 
     /// Processing the decided value failed for the given height and round.

--- a/tests/localdev/NativeFiatToken.test.ts
+++ b/tests/localdev/NativeFiatToken.test.ts
@@ -1740,7 +1740,7 @@ describe('NativeFiatToken', () => {
     it('delegateCall USDC.transfer', async () => {
       const { receipt, balances, helper } = await testCallType({ functionName: 'delegateCall', fn: 'transfer' })
       // since the impl address is not set, the delegate call will call to zero address
-      // which will sucess execute with empty return
+      // which will successfully execute with empty return
       receipt.verifyEvents((ev) => {
         ev.expectCount(1).expectExecutionResult({ helper, success: true, result: '0x' })
       })
@@ -1768,7 +1768,7 @@ describe('NativeFiatToken', () => {
     it('delegateCall USDC.mint', async () => {
       const { receipt, balances, helper } = await testCallType({ functionName: 'delegateCall', fn: 'mint' })
       // since the impl address is not set, the delegate call will call to zero address
-      // which will sucess execute with empty return
+      // which will successfully execute with empty return
       receipt.verifyEvents((ev) => {
         ev.expectCount(1).expectExecutionResult({ helper, success: true, result: '0x' })
       })


### PR DESCRIPTION
## Summary

Fixed minor spelling errors in code comments to improve code quality.

## Changes

| File | Before | After |
|------|--------|--------|
| `crates/malachite-app/src/state.rs:82` | `sucessfully` | `successfully` |
| `tests/localdev/NativeFiatToken.test.ts:1743` | `sucess execute` | `successfully execute` |
| `tests/localdev/NativeFiatToken.test.ts:1771` | `sucess execute` | `successfully execute` |

## Checklist

- [x] No functional changes
- [x] Comments only
- [x] All changes are in comment/doc strings