### PR TITLE
docs: add Arc network chain ID reference table to ACCOUNTS.md

### DIFF
--- a/ACCOUNTS.md
+++ b/ACCOUNTS.md
@@ -84,6 +84,19 @@ These accounts are compatible with:
 - ✅ MetaMask
 - ✅ Most Ethereum development tools
 
+## 🔗 Arc Network Chain IDs
+
+When connecting to Arc networks, use the following chain IDs:
+
+| Network | Chain ID | Purpose |
+|---------|----------|---------|
+| Local Dev (`arc-localdev`) | `1337` | Local development and testing |
+| Devnet (`arc-devnet`) | `5042001` | Arc development network |
+| Testnet (`arc-testnet`) | `5042002` | Public Arc testnet |
+| Mainnet (`arc-mainnet`) | `5042` | Arc production mainnet |
+
+These chain IDs are defined in the genesis configuration files under `assets/{network}/genesis.config.ts`.
+
 ## 📚 References
 
 - [Hardhat Network Configuration](https://hardhat.org/hardhat-network/docs/overview)


### PR DESCRIPTION
## Summary

Added a consolidated reference table of Arc network chain IDs to `ACCOUNTS.md` to help developers quickly identify the correct chain ID for each network.

The table includes Local Dev (`1337`), Devnet (`5042001`), Testnet (`5042002`), and Mainnet (`5042`), along with their purposes and source locations.

## Why

- `ACCOUNTS.md` already documents local dev accounts at chain ID `1337`, but does not list the other Arc networks
- Having all chain IDs in one place reduces confusion and prevents developers from using incorrect chain IDs (e.g., `1516` mentioned in some external documentation is not a valid Arc chain ID)
- The chain IDs are sourced from the genesis config files at `assets/{network}/genesis.config.ts`

## Changes

- Added a `## 🔗 Arc Network Chain IDs` section to `ACCOUNTS.md`
- Listed all four Arc networks with their chain IDs and purposes

## Checklist

- [x] Documentation only — no functional code changes
- [x] Chain IDs verified against genesis config files in the repo