### PR TITLE
fix: verify and document Prague EVM support in hardhat.config.ts

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,6 +48,9 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
+      // Prague EVM is enabled from genesis on all Arc networks (localdev, devnet, testnet, mainnet).
+      // Verified: assets/*/genesis.json all set "pragueTime": 0.
+      // Ref: https://github.com/circlefin/arc-node/issues/96
       evmVersion: 'prague',
     },
   },


### PR DESCRIPTION
## Summary

Closes #96

Investigated whether Arc networks support Prague EVM opcodes (EIP-7702) and verified that `evmVersion: 'prague'` is correct for all Arc environments.

## Verification

Checked the genesis configuration for all four Arc networks:

```json
// assets/localdev/genesis.json
// assets/devnet/genesis.json
// assets/testnet/genesis.json
// assets/mainnet/genesis.json

{
  "shanghaiTime": 0,
  "cancunTime": 0,
  "pragueTime": 0
}
```

All genesis configs set `pragueTime: 0`, confirming Prague EVM is enabled from genesis on every Arc network.

## Changes

Added a clarifying comment in `hardhat.config.ts` documenting the verification, so future developers using this config as a reference understand that `prague` is intentional and verified.

## Checklist

- [x] Verified Prague support in genesis configs
- [x] No functional code changes — comment only
- [x] `make lint` passes
- [x] References #96