### PR TITLE
fix: bump Docker subnet base to avoid conflicts with common VPS networks

### DIFF
--- a/crates/quake/src/manifest/subnets.rs
+++ b/crates/quake/src/manifest/subnets.rs
@@ -23,7 +23,7 @@ use crate::node::{CidrBlock, NodeName, SubnetName};
 
 /// Subnet index offset: user-defined subnets start at 172.21.x.x to avoid
 /// conflicting with the base Docker network at 172.19.x.x / 172.20.x.x.
-const SUBNET_INDEX_BASE: usize = 21;
+const SUBNET_INDEX_BASE: usize = 23;
 
 /// Subnets derived from the manifest.
 #[derive(Serialize, Clone, Debug, PartialEq, Default)]
@@ -353,8 +353,8 @@ mod tests {
         .into();
         let subnets = Subnets::new(&node_subnets);
         let cidr = subnets.cidr_map();
-        assert_eq!(cidr.get("A").unwrap(), "172.21.0.0/16");
-        assert_eq!(cidr.get("B").unwrap(), "172.22.0.0/16");
+        assert_eq!(cidr.get("A").unwrap(), "172.23.0.0/16");
+        assert_eq!(cidr.get("B").unwrap(), "172.24.0.0/16");
     }
 
     #[test]
@@ -368,7 +368,7 @@ mod tests {
         let subnets = Subnets::new(&node_subnets);
         assert_eq!(
             subnets.subnet_indexes_for("node2"),
-            vec![("A".to_string(), 21), ("B".to_string(), 22)]
+            vec![("A".to_string(), 23), ("B".to_string(), 24)]
         );
     }
 

--- a/crates/quake/templates/local/compose-monitoring.yaml.hbs
+++ b/crates/quake/templates/local/compose-monitoring.yaml.hbs
@@ -64,4 +64,4 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.20.0.0/16
+        - subnet: 172.22.0.0/16

--- a/crates/quake/templates/local/compose.yaml.hbs
+++ b/crates/quake/templates/local/compose.yaml.hbs
@@ -446,7 +446,7 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.20.0.0/16
+        - subnet: 172.22.0.0/16
   # Non-internal network for port publishing from containers on internal subnet networks
   host-access:
     driver: bridge


### PR DESCRIPTION
## Problem
Running `make testnet` fails with:
  failed to create network arc_testnet_blockscout: invalid pool request: 
  Pool overlaps with other one on this address space

SUBNET_INDEX_BASE = 21 causes Arc to claim 172.21.0.0/16 and 172.20.0.0/16,
which are commonly occupied on VPS environments by:
- docker_default (172.20.0.0/16)
- monitoring leftovers (172.21.0.0/16)
- Other node software (nesa, quip, etc.)

## Fix
- Bump SUBNET_INDEX_BASE from 21 to 23
- Update hardcoded blockscout/monitoring template subnets from 172.20 to 172.22
- Update unit tests to match

## Tested
Verified `make testnet` runs successfully on Ubuntu 22.04 VPS with
existing Docker networks occupying 172.17–172.21.