### PR TITLE
consensus missed round metric

### DIFF
--- a/crates/malachite-app/METRICS.md
+++ b/crates/malachite-app/METRICS.md
@@ -74,6 +74,13 @@ This application exposes Prometheus metrics on the `/metrics` endpoint. The foll
 - **`arc_malachite_app_height_restart_count`** (Counter)
   - **Description:** Number of times the consensus height has been restarted due to errors or recovery scenarios.
 
+- **`arc_malachite_app_consensus_round_missed`** (Counter)
+  - **Description:** Number of consensus rounds that failed to decide before advancing to the next round.
+  - **Labels:**
+    - `proposer`: Address of the validator that was proposer for the missed round.
+    - `height`: Current height of the chain.
+    - `round`: The round number that failed to decide.
+
 - **`arc_malachite_app_sync_fell_behind_count`** (Counter)
   - **Description:** Number of times the node fell behind and transitioned from InSync to CatchingUp.
 

--- a/crates/malachite-app/src/handlers/started_round.rs
+++ b/crates/malachite-app/src/handlers/started_round.rs
@@ -97,17 +97,20 @@ async fn on_started_round(
     assert!(round != Round::Nil, "Round cannot be Nil");
     assert!(round >= state.current_round, "Round cannot go backwards");
 
-    if round.as_i64() > 0 {
-        let current_round = round.as_u32().expect("round is defined");
-        let missed_round = Round::new(current_round.saturating_sub(1));
+    let mut missed_round = state.current_round.or(Round::Some(0));
+
+    while missed_round < round {
         let missed_proposer = state
             .ctx
             .proposer_selector
             .select_proposer(state.validator_set(), height, missed_round)
             .address;
-        state
-            .metrics()
-            .inc_consensus_round_missed(missed_proposer, height, missed_round);
+
+        warn!(%missed_proposer, %height, %missed_round, "Consensus round missed");
+
+        state.metrics().inc_consensus_round_missed(missed_proposer);
+
+        missed_round = missed_round.increment();
     }
 
     state.current_round = round;

--- a/crates/malachite-app/src/handlers/started_round.rs
+++ b/crates/malachite-app/src/handlers/started_round.rs
@@ -97,6 +97,19 @@ async fn on_started_round(
     assert!(round != Round::Nil, "Round cannot be Nil");
     assert!(round >= state.current_round, "Round cannot go backwards");
 
+    if round.as_i64() > 0 {
+        let current_round = round.as_u32().expect("round is defined");
+        let missed_round = Round::new(current_round.saturating_sub(1));
+        let missed_proposer = state
+            .ctx
+            .proposer_selector
+            .select_proposer(state.validator_set(), height, missed_round)
+            .address;
+        state
+            .metrics()
+            .inc_consensus_round_missed(missed_proposer, height, missed_round);
+    }
+
     state.current_round = round;
     state.current_proposer = Some(proposer);
 

--- a/crates/malachite-app/src/metrics/app.rs
+++ b/crates/malachite-app/src/metrics/app.rs
@@ -23,7 +23,7 @@ use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use arc_consensus_types::ConsensusParams;
-use arc_consensus_types::{Address, Height, Round, ValidatorSet};
+use arc_consensus_types::{Address, ValidatorSet};
 use malachitebft_app_channel::app::metrics::prometheus::encoding::{
     EncodeLabelSet, EncodeLabelValue, LabelValueEncoder,
 };
@@ -480,22 +480,17 @@ impl AppMetrics {
     }
 
     /// Record that a consensus round failed to decide before advancing.
-    pub fn inc_consensus_round_missed(&self, proposer: Address, height: Height, round: Round) {
+    pub fn inc_consensus_round_missed(&self, proposer: Address) {
         self.consensus_round_missed
-            .get_or_create(&RoundMissedLabel::new(proposer, height, round))
+            .get_or_create(&RoundMissedLabel::new(proposer))
             .inc();
     }
 
     /// Total number of missed consensus rounds since start.
     #[cfg(test)]
-    pub fn get_consensus_round_missed_count(
-        &self,
-        proposer: Address,
-        height: Height,
-        round: Round,
-    ) -> u64 {
+    pub fn get_consensus_round_missed_count(&self, proposer: Address) -> u64 {
         self.consensus_round_missed
-            .get_or_create(&RoundMissedLabel::new(proposer, height, round))
+            .get_or_create(&RoundMissedLabel::new(proposer))
             .get()
     }
 }
@@ -550,16 +545,12 @@ impl EncodeLabelValue for AsLabelValue<u64> {
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct RoundMissedLabel {
     proposer: AsLabelValue<Address>,
-    height: AsLabelValue<u64>,
-    round: AsLabelValue<i64>,
 }
 
 impl RoundMissedLabel {
-    fn new(proposer: Address, height: Height, round: Round) -> Self {
+    fn new(proposer: Address) -> Self {
         Self {
             proposer: AsLabelValue(proposer),
-            height: AsLabelValue(height.as_u64()),
-            round: AsLabelValue(round.as_i64()),
         }
     }
 }
@@ -706,21 +697,10 @@ mod tests {
         let metrics = AppMetrics::new();
         let proposer = Address::new([0xAA; 20]);
 
-        metrics.inc_consensus_round_missed(proposer, Height::new(1), Round::new(0));
-        metrics.inc_consensus_round_missed(proposer, Height::new(2), Round::new(0));
-        metrics.inc_consensus_round_missed(proposer, Height::new(2), Round::new(1));
+        metrics.inc_consensus_round_missed(proposer);
+        metrics.inc_consensus_round_missed(proposer);
+        metrics.inc_consensus_round_missed(proposer);
 
-        assert_eq!(
-            metrics.get_consensus_round_missed_count(proposer, Height::new(1), Round::new(0)),
-            1
-        );
-        assert_eq!(
-            metrics.get_consensus_round_missed_count(proposer, Height::new(2), Round::new(0)),
-            1
-        );
-        assert_eq!(
-            metrics.get_consensus_round_missed_count(proposer, Height::new(2), Round::new(1)),
-            1
-        );
+        assert_eq!(metrics.get_consensus_round_missed_count(proposer), 3);
     }
 }

--- a/crates/malachite-app/src/metrics/app.rs
+++ b/crates/malachite-app/src/metrics/app.rs
@@ -23,7 +23,7 @@ use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use arc_consensus_types::ConsensusParams;
-use arc_consensus_types::{Address, ValidatorSet};
+use arc_consensus_types::{Address, Height, Round, ValidatorSet};
 use malachitebft_app_channel::app::metrics::prometheus::encoding::{
     EncodeLabelSet, EncodeLabelValue, LabelValueEncoder,
 };
@@ -111,6 +111,9 @@ pub struct Inner {
     /// Number of blocks replayed from CL to EL during startup handshake
     handshake_replay_blocks: Gauge<u64, AtomicU64>,
 
+    /// Number of consensus rounds that failed to decide before advancing to the next round
+    consensus_round_missed: Family<RoundMissedLabel, Counter>,
+
     /// Internal state recording the previous validator set.
     /// Useful field to manage validators' metrics.
     /// This field is only accessible internally, and is not a metrics itself.
@@ -145,6 +148,7 @@ impl Inner {
             pending_proposal_parts_count: Gauge::default(),
             consensus_params: Family::default(),
             handshake_replay_blocks: Gauge::default(),
+            consensus_round_missed: Family::default(),
         }
     }
 }
@@ -278,6 +282,12 @@ impl AppMetrics {
                 "handshake_replay_blocks",
                 "Number of blocks replayed from CL to EL during startup handshake",
                 metrics.handshake_replay_blocks.clone(),
+            );
+
+            registry.register(
+                "consensus_round_missed",
+                "Number of consensus rounds that failed to decide before advancing to the next round",
+                metrics.consensus_round_missed.clone(),
             );
 
             // Register version info as a separate Info metric
@@ -468,6 +478,26 @@ impl AppMetrics {
     pub fn get_handshake_replay_blocks(&self) -> u64 {
         self.handshake_replay_blocks.get()
     }
+
+    /// Record that a consensus round failed to decide before advancing.
+    pub fn inc_consensus_round_missed(&self, proposer: Address, height: Height, round: Round) {
+        self.consensus_round_missed
+            .get_or_create(&RoundMissedLabel::new(proposer, height, round))
+            .inc();
+    }
+
+    /// Total number of missed consensus rounds since start.
+    #[cfg(test)]
+    pub fn get_consensus_round_missed_count(
+        &self,
+        proposer: Address,
+        height: Height,
+        round: Round,
+    ) -> u64 {
+        self.consensus_round_missed
+            .get_or_create(&RoundMissedLabel::new(proposer, height, round))
+            .get()
+    }
 }
 
 impl Default for AppMetrics {
@@ -501,6 +531,35 @@ impl AddressLabel {
     fn new(address: Address) -> Self {
         Self {
             address: AsLabelValue(address),
+        }
+    }
+}
+
+impl EncodeLabelValue for AsLabelValue<i64> {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.write_fmt(format_args!("{}", self.0))
+    }
+}
+
+impl EncodeLabelValue for AsLabelValue<u64> {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.write_fmt(format_args!("{}", self.0))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct RoundMissedLabel {
+    proposer: AsLabelValue<Address>,
+    height: AsLabelValue<u64>,
+    round: AsLabelValue<i64>,
+}
+
+impl RoundMissedLabel {
+    fn new(proposer: Address, height: Height, round: Round) -> Self {
+        Self {
+            proposer: AsLabelValue(proposer),
+            height: AsLabelValue(height.as_u64()),
+            round: AsLabelValue(round.as_i64()),
         }
     }
 }
@@ -639,6 +698,29 @@ mod tests {
         assert!(
             !buf.contains("0x"),
             "Metrics should not contain 0x prefix: {buf}"
+        );
+    }
+
+    #[test]
+    fn test_consensus_round_missed_and_blocks_proposed_counters() {
+        let metrics = AppMetrics::new();
+        let proposer = Address::new([0xAA; 20]);
+
+        metrics.inc_consensus_round_missed(proposer, Height::new(1), Round::new(0));
+        metrics.inc_consensus_round_missed(proposer, Height::new(2), Round::new(0));
+        metrics.inc_consensus_round_missed(proposer, Height::new(2), Round::new(1));
+
+        assert_eq!(
+            metrics.get_consensus_round_missed_count(proposer, Height::new(1), Round::new(0)),
+            1
+        );
+        assert_eq!(
+            metrics.get_consensus_round_missed_count(proposer, Height::new(2), Round::new(0)),
+            1
+        );
+        assert_eq!(
+            metrics.get_consensus_round_missed_count(proposer, Height::new(2), Round::new(1)),
+            1
         );
     }
 }


### PR DESCRIPTION
This adds a metrics to measure the missed rounds with labels including the proposer height and the round missed. This is helpful to create alerting rules for missed rounds and identify validators that might be having issues.

<img width="1495" height="318" alt="Screenshot 2026-06-07 at 7 36 13 PM" src="https://github.com/user-attachments/assets/92c6d360-18b5-48e5-9370-695d07a3d2f1" />
