### PR TITLE
docs: clarify Arc Testnet chain ID is 5042002, not 1516

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ To connect a wallet to Arc Testnet:
 > ```
 
 > [!NOTE]
-> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app** and
-> documentation lives at **https://docs.arc.network**. Older explorer URLs such as
-> `explorer.testnet.arc.network`, `explorer.arc.io`, and `docs.arc.io` are dead
-> (unreachable, login-gated, or 404) — do not use them in wallet `blockExplorerUrls`
-> configs or transaction links.
+> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app**. Other
+> explorer URLs that circulate in older guides — `explorer.testnet.arc.network`
+> (unreachable) and `explorer.arc.io` (team-login-gated) — are not publicly usable;
+> don't put them in wallet `blockExplorerUrls` configs or transaction links.
 
 ## Install and Run a Node
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,39 @@ Arc is an open EVM-compatible layer 1 built on [Malachite](https://github.com/ci
 - 🗳️ **[Consensus](crates/malachite-app/README.md)** - Consensus binary and configuration
 - More: see Arc [developer docs](https://docs.arc.network/arc/concepts/welcome-to-arc) for guides, APIs, and specs
 
+## Networks
+
+Arc's official chain IDs:
+
+| Network | Chain ID  | Hex        |
+| ------- | --------- | ---------- |
+| Mainnet | `5042`    | `0x13b2`   |
+| Testnet | `5042002` | `0x4cef52` |
+| Devnet  | `5042001` | `0x4cef51` |
+
+To connect a wallet to Arc Testnet:
+
+| Parameter       | Value                           |
+| --------------- | ------------------------------- |
+| Network name    | Arc Testnet                     |
+| Chain ID        | `5042002` (`0x4cef52`)          |
+| RPC URL         | https://rpc.testnet.arc.network |
+| Currency symbol | USDC                            |
+| Block explorer  | https://testnet.arcscan.app     |
+
+> [!IMPORTANT]
+> Arc Testnet's chain ID is **`5042002`** (`0x4cef52`). Some third-party chain
+> registries and older community guides incorrectly list `1516` — that value is
+> **wrong** and will cause wallet connection failures. You can verify the chain
+> ID returned by a node directly:
+>
+> ```bash
+> curl -X POST https://rpc.testnet.arc.network \
+>   -H "Content-Type: application/json" \
+>   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+> # {"result":"0x4cef52"}  =  5042002
+> ```
+
 ## Install and Run a Node
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ To connect a wallet to Arc Testnet:
 > # {"result":"0x4cef52"}  =  5042002
 > ```
 
+> [!NOTE]
+> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app** and
+> documentation lives at **https://docs.arc.network**. Older explorer URLs such as
+> `explorer.testnet.arc.network`, `explorer.arc.io`, and `docs.arc.io` are dead
+> (unreachable, login-gated, or 404) — do not use them in wallet `blockExplorerUrls`
+> configs or transaction links.
+
 ## Install and Run a Node
 
 ### Install


### PR DESCRIPTION
Closes #94.
Fixes #81.

## Summary

Arc Testnet's chain ID is `5042002` (`0x4cef52`), but some third-party chain registries and older community guides circulate the incorrect value `1516`, causing wallet connection failures. Separately, several Arc Testnet block explorer URLs that circulate in external guides and wallet configs are dead (unreachable / login-gated).

Note: this repo's code and config were already consistent on `5042002`, and contained **no** dead explorer URLs — both bad values circulate outside this repo. The gap was the lack of a clear, discoverable network reference for people setting up wallets/tooling. This PR adds one.

## Changes

- Add a **Networks** section to `README.md`:
  - Official chain IDs for Mainnet (`5042`), Testnet (`5042002`), Devnet (`5042001`)
  - Arc Testnet wallet-connection parameters (chain ID, RPC URL, currency, explorer)
  - A prominent `[!IMPORTANT]` callout that `1516` is incorrect, with a `curl` snippet to verify the chain ID straight from a node (#94)
  - A `[!NOTE]` callout naming `testnet.arcscan.app` as the canonical block explorer and flagging the non-usable `explorer.testnet.arc.network` (unreachable) and `explorer.arc.io` (team-login-gated) URLs (#81)

## Out of scope

Issue #94 also suggests submitting a PR to `ethereum-lists/chains`, and #81's remaining fixes live in third-party registries / MetaMask guides. Those are external registries, separate from this repo.

## Test plan

- [ ] README renders correctly on GitHub (tables + callouts)
- [ ] Chain IDs match `crates/shared/src/chain_ids.rs`