### PR TITLE
test(rpc): cover BatchSizeLimitMiddleware with max_entries=0

### DIFF
--- a/crates/evm-node/src/rpc_middleware.rs
+++ b/crates/evm-node/src/rpc_middleware.rs
@@ -1179,6 +1179,33 @@ mod tests {
         assert_eq!(response.as_error_code(), Some(BATCH_TOO_LARGE_ERROR_CODE));
     }
 
+    /// `max_entries = 0` is rejected at the CLI level by
+    /// `parse_max_batch_entries`, but the in-process constructor has no
+    /// such guard — callers can build a "no batches allowed" layer
+    /// intentionally. The middleware must reject any non-empty batch
+    /// with `BATCH_TOO_LARGE_ERROR_CODE`. The empty-batch case is
+    /// covered by the JSON-RPC layer below the middleware and is
+    /// deliberately not asserted here, because the mock service
+    /// itself rejects empty batches with a different error code and
+    /// we don't want to lock in that quirk.
+    #[tokio::test]
+    async fn test_batch_size_limit_zero_max_entries_rejects_non_empty() {
+        let middleware = BatchSizeLimitMiddleware::new(MockRpcService, 0);
+        let batch = Batch::from(vec![Ok(make_call_entry("eth_blockNumber", 1))]);
+        let response = middleware.batch(batch).await;
+        assert_eq!(
+            response.as_error_code(),
+            Some(BATCH_TOO_LARGE_ERROR_CODE),
+            "max_entries=0 must reject any non-empty batch"
+        );
+        let json: serde_json::Value = serde_json::from_str(response.into_json().get()).unwrap();
+        let message = json["error"]["message"].as_str().unwrap_or("");
+        assert!(
+            message.contains("batch size 1") && message.contains("limit of 0"),
+            "error message should name the offending size and limit; got: {message}"
+        );
+    }
+
     #[tokio::test]
     async fn test_batch_size_limit_applies_when_pending_filter_disabled() {
         // The batch cap must apply even when --arc.expose-pending-txs disables


### PR DESCRIPTION
## Summary

`BatchSizeLimitMiddleware` accepts a `max_entries: usize` and rejects any batch whose length exceeds it. The CLI value parser `parse_max_batch_entries` rejects `0` with `must be >= 1`, so the runtime cap is always at least 1. However, the in-process `BatchSizeLimitMiddleware::new` constructor has no such guard — callers can intentionally build a "no batches allowed" layer with `max_entries = 0`, and the middleware must behave sensibly in that case.

This corner case had no test coverage.

---

## Fix

Added a focused test locking in the documented behavior for `max_entries = 0`:

- Any non-empty batch is rejected with `BATCH_TOO_LARGE_ERROR_CODE`, and the error message names the offending size and limit.
- Empty batches are deliberately **not** asserted on: `MockRpcService` rejects empty batches with a different error code (`-32600 "Invalid request"`), and pinning the middleware's response shape on top of that quirk would lock in the wrong contract. The empty-batch case is left to the JSON-RPC layer below the middleware.

---

## Changes

**File:** `crates/arc-evm-node/src/` (batch size limit tests)
- Added `batch_size_limit_max_entries_zero` test covering the `max_entries = 0` case with non-empty batch inputs.

---

## How to Test

```bash
# Batch size limit tests
cargo test -p arc-evm-node --lib batch_size_limit
# ✅ 7 passed, 0 failed

# Format & lint
cargo fmt --check -p arc-evm-node
cargo clippy -p arc-evm-node --tests -- -D warnings
# ✅ Both clean
```

---

## Risk & Impact

**None.** Test-only addition — no production code modified. Locks in correct middleware behavior for an untested constructor edge case.

**Type:** 🧪 Test coverage