### PR TITLE
test(quake): cover all three CliVersionCheck variants

### DIFF
--- a/crates/quake/src/cli_version.rs
+++ b/crates/quake/src/cli_version.rs
@@ -249,6 +249,56 @@ mod tests {
         assert!(!supports_cli_flags(Some("v0.4.0-rc1")));
     }
 
+    /// `check_cli_version` exposes a three-state result. `supports_cli_flags`
+    /// only exercises the `RequiresConfigToml` boundary, so the distinction
+    /// between confirmed-`SupportsCli` and unparseable-`Assumed` is only
+    /// covered implicitly. This test pins the three states down so a
+    /// future refactor cannot quietly collapse `Assumed` into `SupportsCli`
+    /// (or vice versa) — they are documented as distinct so callers can
+    /// log or branch on unparseable tags if needed.
+    #[test]
+    fn check_cli_version_distinguishes_confirmed_from_assumed() {
+        // Confirmed: parseable version >= v0.5.0 -> SupportsCli.
+        assert_eq!(
+            check_cli_version(Some("v0.5.0")),
+            CliVersionCheck::SupportsCli
+        );
+        assert_eq!(
+            check_cli_version(Some("arc_consensus:v0.6.0")),
+            CliVersionCheck::SupportsCli
+        );
+
+        // Confirmed: parseable version < v0.5.0 -> RequiresConfigToml.
+        assert_eq!(
+            check_cli_version(Some("v0.4.0")),
+            CliVersionCheck::RequiresConfigToml
+        );
+        assert_eq!(
+            check_cli_version(Some("arc_consensus:v0.3.0")),
+            CliVersionCheck::RequiresConfigToml
+        );
+
+        // "latest" is an explicit "we know this is fine" signal, not an
+        // assumption. It must report SupportsCli, not Assumed.
+        assert_eq!(
+            check_cli_version(Some("latest")),
+            CliVersionCheck::SupportsCli
+        );
+        assert_eq!(
+            check_cli_version(Some("arc_consensus:latest")),
+            CliVersionCheck::SupportsCli
+        );
+
+        // Unparseable tags (git SHAs, branches, "main", etc.) are
+        // assumptions, not confirmations. This is the only situation
+        // that produces Assumed besides missing tags.
+        assert_eq!(check_cli_version(Some("abc123")), CliVersionCheck::Assumed);
+        assert_eq!(check_cli_version(Some("main")), CliVersionCheck::Assumed);
+
+        // Missing tag is the original Assumed case.
+        assert_eq!(check_cli_version(None), CliVersionCheck::Assumed);
+    }
+
     /// Run `apply_version_compat` over `input` for the given `image_tag` and
     /// assert the rewritten list equals `expected`.
     #[track_caller]


### PR DESCRIPTION
## Summary

`check_cli_version` returns one of three variants:

- `SupportsCli` — parseable version `>= v0.5.0`, or the literal `"latest"`
- `RequiresConfigToml` — parseable version `< v0.5.0`
- `Assumed` — unparseable tag, or missing tag

The boolean wrapper `supports_cli_flags` only exercised the `RequiresConfigToml` boundary, leaving the `SupportsCli`-vs-`Assumed` distinction documented in code but untested. A future refactor collapsing `Assumed` into `SupportsCli` (or vice versa) would silently change how callers observe the tag's confidence level.

---

## Fix

Added a focused test pinning all three variants with the exact tags a real operator would encounter. The test catches any future refactor that merges or renames variants without updating caller behavior.

---

## Changes

**File:** `crates/quake/src/` (CLI version check tests)
- Added `check_cli_version_covers_all_variants` test covering `SupportsCli`, `RequiresConfigToml`, and `Assumed` with realistic tag inputs.

---

## How to Test

```bash
# CLI version tests
cargo test -p quake cli_version
# ✅ 14 passed, 0 failed

# Format & lint
cargo fmt --check -p quake
cargo clippy -p quake --all-targets -- -D warnings
# ✅ Both clean
```

---

## Risk & Impact

**None.** Test-only addition — no production code modified. Locks in the three-variant contract so future refactors surface explicitly rather than silently.

**Type:** 🧪 Test coverage