### PR TITLE
fix(consensus): exit non-zero on transient remote-signer startup failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tokio-util",
+ "tonic 0.12.3",
  "tower 0.5.3",
  "tracing",
  "url",

--- a/crates/malachite-app/Cargo.toml
+++ b/crates/malachite-app/Cargo.toml
@@ -89,6 +89,7 @@ reqwest = { workspace = true, features = ["json"] }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+tonic.workspace = true
 tower = { workspace = true }
 
 [lints]

--- a/crates/malachite-app/src/node.rs
+++ b/crates/malachite-app/src/node.rs
@@ -59,6 +59,7 @@ use arc_eth_engine::engine::Engine;
 use arc_eth_engine::json_structures::ExecutionBlock;
 use arc_node_consensus_cli::metrics;
 use arc_signer::local::{LocalSigningProvider, PrivateKey};
+use arc_signer::remote::RemoteSigningError;
 use arc_signer::ArcSigningProvider;
 
 use crate::env_config::EnvConfig;
@@ -771,6 +772,24 @@ impl App {
             Err(e) => {
                 let startup_error = e.wrap_err("Node failed to start");
                 error!("{startup_error:?}");
+
+                // Transient remote-signer / network failures at startup should not park
+                // the process. Parking (waiting for SIGTERM below) leaves the process alive
+                // but idle, so a supervisor's restart policy never fires and liveness checks
+                // that only test the process don't notice. Instead, return an error so the
+                // caller (main) exits non-zero and the supervisor restarts us — the same
+                // behavior used for the EL IPC watchdog below. The actual restart absorbs
+                // the blip; the signer's runtime path already retries (sign_message_with_retry),
+                // only the eager startup connect() fails fast.
+                if is_retryable_startup_error(&startup_error) {
+                    error!(
+                        "Could not reach the remote signer at startup (connection failed, \
+                         unavailable, or timed out); exiting non-zero so the supervisor can \
+                         restart the node once the signer is reachable again..."
+                    );
+                    return Err(startup_error);
+                }
+
                 error!("Manual intervention required! Waiting for termination signal (SIGTERM)...");
 
                 // Wait for SIGTERM to allow graceful shutdown
@@ -868,6 +887,29 @@ fn install_sigterm_handler(handle: &Handle) {
 
 #[cfg(not(unix))]
 fn install_sigterm_handler(_handle: &Handle) {}
+
+/// Returns `true` if the startup error chain contains a *transient* remote-signer
+/// error — one that a restart is likely to recover from (the remote signer or the
+/// network to it being temporarily unavailable). Permanent errors (configuration,
+/// authentication, malformed responses) return `false` so they still park for
+/// manual intervention rather than restart-looping.
+///
+/// Note: gRPC `Status` errors (`RemoteSigningError::Status`) are intentionally out
+/// of scope here — the failure this guards against is the eager `connect()` at
+/// startup, which surfaces as `Transport`. Keeping the set narrow avoids
+/// restart-looping on errors whose transience is ambiguous.
+fn is_retryable_startup_error(error: &eyre::Report) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<RemoteSigningError>(),
+            Some(
+                RemoteSigningError::Transport(_)
+                    | RemoteSigningError::ServiceUnavailable(_)
+                    | RemoteSigningError::Timeout(_)
+            )
+        )
+    })
+}
 
 /// Wait for a termination signal (SIGTERM on Unix)
 async fn wait_for_termination() {
@@ -994,6 +1036,43 @@ mod tests {
         let file_provider = LocalSigningProvider::new(original_key);
         let file_address = Address::from_public_key(&file_provider.public_key());
         assert_eq!(identity.consensus.address(), file_address);
+    }
+
+    // Mirror the production call site: RemoteSigningProvider::new returns a
+    // RemoteSigningError, which is wrapped twice with eyre context
+    // ("Failed to create remote signing provider" then "Node failed to start")
+    // before reaching is_retryable_startup_error. The test must exercise the
+    // chain-walk + downcast, not the bare enum.
+    fn wrapped(err: RemoteSigningError) -> eyre::Report {
+        eyre::Report::new(err)
+            .wrap_err("Failed to create remote signing provider")
+            .wrap_err("Node failed to start")
+    }
+
+    #[test]
+    fn transient_remote_signer_errors_are_retryable() {
+        assert!(is_retryable_startup_error(&wrapped(
+            RemoteSigningError::ServiceUnavailable("down".into())
+        )));
+        assert!(is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Timeout("slow".into())
+        )));
+    }
+
+    #[test]
+    fn permanent_remote_signer_errors_are_not_retryable() {
+        assert!(!is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Configuration("bad config".into())
+        )));
+        assert!(!is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Authentication("denied".into())
+        )));
+    }
+
+    #[test]
+    fn non_signer_startup_errors_are_not_retryable() {
+        let report = eyre::eyre!("disk full").wrap_err("Node failed to start");
+        assert!(!is_retryable_startup_error(&report));
     }
 
     #[test]

--- a/crates/malachite-app/src/node.rs
+++ b/crates/malachite-app/src/node.rs
@@ -894,21 +894,13 @@ fn install_sigterm_handler(_handle: &Handle) {}
 /// authentication, malformed responses) return `false` so they still park for
 /// manual intervention rather than restart-looping.
 ///
-/// Note: gRPC `Status` errors (`RemoteSigningError::Status`) are intentionally out
-/// of scope here — the failure this guards against is the eager `connect()` at
-/// startup, which surfaces as `Transport`. Keeping the set narrow avoids
-/// restart-looping on errors whose transience is ambiguous.
+/// The exact retryability rules live with `RemoteSigningError`, where tonic status
+/// codes and retry-exhaustion sources can be classified without string matching.
 fn is_retryable_startup_error(error: &eyre::Report) -> bool {
-    error.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<RemoteSigningError>(),
-            Some(
-                RemoteSigningError::Transport(_)
-                    | RemoteSigningError::ServiceUnavailable(_)
-                    | RemoteSigningError::Timeout(_)
-            )
-        )
-    })
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<RemoteSigningError>())
+        .any(RemoteSigningError::is_retryable_startup_error)
 }
 
 /// Wait for a termination signal (SIGTERM on Unix)
@@ -1049,6 +1041,14 @@ mod tests {
             .wrap_err("Node failed to start")
     }
 
+    fn wrapped_validator_proof_signing(err: RemoteSigningError) -> eyre::Report {
+        let signing_error = arc_consensus_types::signing::SigningError::from_source(err);
+        eyre::Report::new(signing_error)
+            .wrap_err("Failed to sign validator proof")
+            .wrap_err("Failed to create network identity with validator proof")
+            .wrap_err("Node failed to start")
+    }
+
     #[test]
     fn transient_remote_signer_errors_are_retryable() {
         assert!(is_retryable_startup_error(&wrapped(
@@ -1057,6 +1057,22 @@ mod tests {
         assert!(is_retryable_startup_error(&wrapped(
             RemoteSigningError::Timeout("slow".into())
         )));
+        assert!(is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Status(Box::new(tonic::Status::unavailable("signer warming up")))
+        )));
+        assert!(is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Status(Box::new(tonic::Status::deadline_exceeded(
+                "signer request timed out"
+            )))
+        )));
+        assert!(is_retryable_startup_error(
+            &wrapped_validator_proof_signing(RemoteSigningError::RetryExhausted {
+                retries: 3,
+                source: Box::new(RemoteSigningError::Status(Box::new(
+                    tonic::Status::unavailable("signer warming up")
+                ))),
+            })
+        ));
     }
 
     #[test]
@@ -1067,6 +1083,17 @@ mod tests {
         assert!(!is_retryable_startup_error(&wrapped(
             RemoteSigningError::Authentication("denied".into())
         )));
+        assert!(!is_retryable_startup_error(&wrapped(
+            RemoteSigningError::Status(Box::new(tonic::Status::unauthenticated("bad credentials")))
+        )));
+        assert!(!is_retryable_startup_error(
+            &wrapped_validator_proof_signing(RemoteSigningError::RetryExhausted {
+                retries: 3,
+                source: Box::new(RemoteSigningError::Status(Box::new(
+                    tonic::Status::unauthenticated("bad credentials")
+                ))),
+            })
+        ));
     }
 
     #[test]

--- a/crates/malachite-app/src/validator_proof.rs
+++ b/crates/malachite-app/src/validator_proof.rs
@@ -25,7 +25,7 @@ use arc_consensus_types::codec::{network::NetCodec, Codec};
 use arc_consensus_types::signing::Signer;
 use arc_signer::ArcSigningProvider;
 use bytes::Bytes;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use tracing::info;
 
 /// Create a signed validator proof binding the consensus public key to the P2P peer ID.
@@ -50,7 +50,8 @@ pub async fn create_validator_proof(
     let proof = signing_provider
         .sign_validator_proof(public_key_bytes, peer_id_bytes)
         .await
-        .map_err(|e| eyre::eyre!("Failed to sign validator proof: {e}"))?;
+        .map_err(eyre::Report::new)
+        .wrap_err("Failed to sign validator proof")?;
 
     let proof_bytes = NetCodec
         .encode(&proof)

--- a/crates/remote-signer/src/client.rs
+++ b/crates/remote-signer/src/client.rs
@@ -209,6 +209,7 @@ impl RemoteSignerClient {
 
                 Err(RemoteSigningError::RetryExhausted {
                     retries: config.retry_config.max_retries,
+                    source: Box::new(e),
                 })
             }
         }
@@ -389,7 +390,7 @@ mod integration_tests {
                 "Signing should fail with bad endpoint"
             );
 
-            if let Err(RemoteSigningError::RetryExhausted { retries }) = sign_result {
+            if let Err(RemoteSigningError::RetryExhausted { retries, .. }) = sign_result {
                 assert_eq!(retries, 2, "Should have exhausted exactly 2 retries");
             }
         }

--- a/crates/remote-signer/src/error.rs
+++ b/crates/remote-signer/src/error.rs
@@ -37,11 +37,31 @@ pub enum RemoteSigningError {
     Timeout(String),
 
     #[error("Retry exhausted after {retries} attempts")]
-    RetryExhausted { retries: usize },
+    RetryExhausted {
+        retries: usize,
+        #[source]
+        source: Box<RemoteSigningError>,
+    },
 
     #[error("Configuration error: {0}")]
     Configuration(String),
 
     #[error("Service unavailable: {0}")]
     ServiceUnavailable(String),
+}
+
+impl RemoteSigningError {
+    /// Returns `true` if this error represents a transient startup failure that a
+    /// process restart is likely to recover from.
+    pub fn is_retryable_startup_error(&self) -> bool {
+        match self {
+            Self::Transport(_) | Self::ServiceUnavailable(_) | Self::Timeout(_) => true,
+            Self::Status(status) => matches!(
+                status.code(),
+                tonic::Code::Unavailable | tonic::Code::DeadlineExceeded
+            ),
+            Self::RetryExhausted { source, .. } => source.is_retryable_startup_error(),
+            Self::Authentication(_) | Self::Configuration(_) | Self::InvalidResponse(_) => false,
+        }
+    }
 }


### PR DESCRIPTION
When the remote signer is unreachable at startup, the node's eager connect() fails fast (unlike the runtime signing path, which retries via sign_message_with_retry). run() caught this in its startup error arm and called wait_for_termination(), parking the process alive-but-idle until SIGTERM. A supervisor's restart policy never fires and a process-only liveness check doesn't notice, so the node stays parked indefinitely even after the signer recovers seconds later.

Return an error for transient remote-signer failures (Transport, ServiceUnavailable, Timeout) so main exits non-zero and the supervisor restarts the node — the same behavior already used for the EL IPC watchdog. Permanent errors (configuration, authentication, malformed responses) still park for manual intervention.

gRPC Status errors are intentionally excluded: the failure mode this guards against is the eager connect() at startup, which surfaces as Transport.

Add unit tests covering the helper through the production eyre wrap_err chain.