### PR TITLE
ci: add public release finalizer

### DIFF
--- a/.github/actions/finalize-release/action.yaml
+++ b/.github/actions/finalize-release/action.yaml
@@ -9,10 +9,6 @@ inputs:
     description: Path to the checked out public repository.
     required: false
     default: .
-  release-namespace:
-    description: Release namespace to enforce.
-    required: false
-    default: auto
   pr-body:
     description: Release PR body.
     required: true
@@ -48,7 +44,6 @@ runs:
       id: finalizer
       shell: bash
       env:
-        RELEASE_NAMESPACE: ${{ inputs.release-namespace }}
         PR_BODY: ${{ inputs.pr-body }}
         PR_BASE_REF: ${{ inputs.pr-base-ref }}
         PR_HEAD_REF: ${{ inputs.pr-head-ref }}

--- a/.github/actions/finalize-release/action.yaml
+++ b/.github/actions/finalize-release/action.yaml
@@ -45,11 +45,12 @@ runs:
       shell: bash
       env:
         MODE: ${{ inputs.mode }}
+        REPOSITORY_PATH: ${{ inputs.repository-path }}
         PR_BODY: ${{ inputs.pr-body }}
         PR_BASE_REF: ${{ inputs.pr-base-ref }}
         PR_HEAD_REF: ${{ inputs.pr-head-ref }}
         MERGE_COMMIT_SHA: ${{ inputs.merge-commit-sha }}
       run: |
         set -euo pipefail
-        cd "${{ inputs.repository-path }}"
+        cd "${REPOSITORY_PATH}"
         bash "${{ github.action_path }}/../../scripts/finalize-release.sh" "${MODE}"

--- a/.github/actions/finalize-release/action.yaml
+++ b/.github/actions/finalize-release/action.yaml
@@ -44,6 +44,7 @@ runs:
       id: finalizer
       shell: bash
       env:
+        MODE: ${{ inputs.mode }}
         PR_BODY: ${{ inputs.pr-body }}
         PR_BASE_REF: ${{ inputs.pr-base-ref }}
         PR_HEAD_REF: ${{ inputs.pr-head-ref }}
@@ -51,4 +52,4 @@ runs:
       run: |
         set -euo pipefail
         cd "${{ inputs.repository-path }}"
-        bash "${{ github.action_path }}/../../scripts/finalize-release.sh" "${{ inputs.mode }}"
+        bash "${{ github.action_path }}/../../scripts/finalize-release.sh" "${MODE}"

--- a/.github/actions/finalize-release/action.yaml
+++ b/.github/actions/finalize-release/action.yaml
@@ -27,10 +27,25 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  namespace:
+    description: Resolved release namespace.
+    value: ${{ steps.finalizer.outputs.namespace }}
+  tag:
+    description: Resolved release tag.
+    value: ${{ steps.finalizer.outputs.tag }}
+  release_branch:
+    description: Resolved release branch.
+    value: ${{ steps.finalizer.outputs.release_branch }}
+  release_kind:
+    description: Resolved release kind.
+    value: ${{ steps.finalizer.outputs.release_kind }}
+
 runs:
   using: composite
   steps:
     - name: Run release finalizer
+      id: finalizer
       shell: bash
       env:
         RELEASE_NAMESPACE: ${{ inputs.release-namespace }}

--- a/.github/actions/finalize-release/action.yaml
+++ b/.github/actions/finalize-release/action.yaml
@@ -1,0 +1,44 @@
+name: Finalize Public Release
+description: Validate or finalize a public release PR.
+
+inputs:
+  mode:
+    description: validate or finalize.
+    required: true
+  repository-path:
+    description: Path to the checked out public repository.
+    required: false
+    default: .
+  release-namespace:
+    description: Release namespace to enforce.
+    required: false
+    default: auto
+  pr-body:
+    description: Release PR body.
+    required: true
+  pr-base-ref:
+    description: Release PR base branch.
+    required: true
+  pr-head-ref:
+    description: Release PR head branch.
+    required: true
+  merge-commit-sha:
+    description: Merge commit SHA for finalize mode.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Run release finalizer
+      shell: bash
+      env:
+        RELEASE_NAMESPACE: ${{ inputs.release-namespace }}
+        PR_BODY: ${{ inputs.pr-body }}
+        PR_BASE_REF: ${{ inputs.pr-base-ref }}
+        PR_HEAD_REF: ${{ inputs.pr-head-ref }}
+        MERGE_COMMIT_SHA: ${{ inputs.merge-commit-sha }}
+      run: |
+        set -euo pipefail
+        cd "${{ inputs.repository-path }}"
+        bash "${{ github.action_path }}/../../scripts/finalize-release.sh" "${{ inputs.mode }}"

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  finalize-release.sh validate
+  finalize-release.sh finalize
+
+Environment:
+  PR_BODY                Pull request body containing release metadata.
+  PR_BASE_REF            Pull request base branch.
+  PR_HEAD_REF            Pull request head branch.
+  MERGE_COMMIT_SHA       Required for finalize mode.
+  RELEASE_NAMESPACE      Optional: auto, production, or test. Defaults to auto.
+USAGE
+}
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+note() {
+  echo "$*" >&2
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    die "${name} is required"
+  fi
+}
+
+extract_body_field() {
+  local label="$1"
+  awk -v label="${label}: " '
+    index($0, label) == 1 {
+      sub(label, "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' <<< "${PR_BODY}"
+}
+
+remote_ref_exists() {
+  local ref="$1"
+  git ls-remote --exit-code origin "${ref}" >/dev/null 2>&1
+}
+
+remote_ref_sha() {
+  local ref="$1"
+  git ls-remote origin "${ref}" | awk 'NR == 1 {print $1}'
+}
+
+ensure_valid_ref() {
+  local ref="$1"
+  git check-ref-format "${ref}" >/dev/null 2>&1 || die "Invalid Git ref: ${ref}"
+}
+
+resolve_namespace() {
+  local requested="${RELEASE_NAMESPACE:-auto}"
+
+  case "${requested}" in
+    auto)
+      if [[ "${TAG}" == test/v* || "${RELEASE_BRANCH}" == test-release/* || "${PR_BASE_REF}" == test-main || "${PR_BASE_REF}" == test-release/* ]]; then
+        NAMESPACE="test"
+      else
+        NAMESPACE="production"
+      fi
+      ;;
+    production|test)
+      NAMESPACE="${requested}"
+      ;;
+    *)
+      die "Invalid RELEASE_NAMESPACE: ${requested}"
+      ;;
+  esac
+
+  case "${NAMESPACE}" in
+    production)
+      TAG_PREFIX="v"
+      RELEASE_BRANCH_PREFIX="release/"
+      MAIN_BRANCH="main"
+      ;;
+    test)
+      TAG_PREFIX="test/v"
+      RELEASE_BRANCH_PREFIX="test-release/"
+      MAIN_BRANCH="test-main"
+      ;;
+  esac
+}
+
+parse_release_metadata() {
+  require_env PR_BODY
+  require_env PR_BASE_REF
+  require_env PR_HEAD_REF
+
+  [[ "${PR_HEAD_REF}" == sync/copybara-export-* ]] || die "Release finalizer only accepts Copybara export branches"
+
+  TAG="$(extract_body_field "Release tag")" || die "PR body is missing 'Release tag: ...'"
+  RELEASE_BRANCH="$(extract_body_field "Release branch")" || die "PR body is missing 'Release branch: ...'"
+  RELEASE_KIND="$(extract_body_field "Release kind" || true)"
+  RELEASE_KIND="${RELEASE_KIND:-patch}"
+
+  case "${RELEASE_KIND}" in
+    patch|minor|major) ;;
+    *) die "Invalid Release kind: ${RELEASE_KIND}" ;;
+  esac
+
+  resolve_namespace
+
+  [[ "${TAG}" == "${TAG_PREFIX}"* ]] || die "${NAMESPACE} release tags must start with ${TAG_PREFIX}: ${TAG}"
+  [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "${NAMESPACE} release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
+
+  ensure_valid_ref "refs/tags/${TAG}"
+  ensure_valid_ref "refs/heads/${RELEASE_BRANCH}"
+  ensure_valid_ref "refs/heads/${MAIN_BRANCH}"
+
+  VERSION="${TAG:${#TAG_PREFIX}}"
+  if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    die "Public finalization only supports final SemVer tags, got ${TAG}"
+  fi
+
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  PATCH="${BASH_REMATCH[3]}"
+  EXPECTED_RELEASE_BRANCH="${RELEASE_BRANCH_PREFIX}${MAJOR}.${MINOR}"
+  [[ "${RELEASE_BRANCH}" == "${EXPECTED_RELEASE_BRANCH}" ]] || die "Release branch must be ${EXPECTED_RELEASE_BRANCH}, got ${RELEASE_BRANCH}"
+
+  EFFECTIVE_RELEASE_KIND="${RELEASE_KIND}"
+  if [[ "${RELEASE_KIND}" == "patch" && "${PATCH}" == "0" ]]; then
+    EFFECTIVE_RELEASE_KIND="minor"
+  fi
+
+  case "${EFFECTIVE_RELEASE_KIND}" in
+    patch)
+      [[ "${PR_BASE_REF}" == "${RELEASE_BRANCH}" ]] || die "Patch release PRs must target ${RELEASE_BRANCH}, got ${PR_BASE_REF}"
+      ;;
+    minor)
+      [[ "${PATCH}" == "0" ]] || die "Minor release PRs require an X.Y.0 tag, got ${TAG}"
+      [[ "${PR_BASE_REF}" == "${MAIN_BRANCH}" ]] || die "Minor release PRs must target ${MAIN_BRANCH}, got ${PR_BASE_REF}"
+      ;;
+    major)
+      [[ "${MINOR}" == "0" && "${PATCH}" == "0" ]] || die "Major release PRs require an X.0.0 tag, got ${TAG}"
+      [[ "${PR_BASE_REF}" == "${MAIN_BRANCH}" ]] || die "Major release PRs must target ${MAIN_BRANCH}, got ${PR_BASE_REF}"
+      ;;
+  esac
+}
+
+validate_remote_preconditions() {
+  if remote_ref_exists "refs/tags/${TAG}"; then
+    die "Release tag already exists: ${TAG}"
+  fi
+
+  case "${EFFECTIVE_RELEASE_KIND}" in
+    patch)
+      remote_ref_exists "refs/heads/${RELEASE_BRANCH}" || die "Patch release branch does not exist: ${RELEASE_BRANCH}"
+      ;;
+    minor|major)
+      if remote_ref_exists "refs/heads/${RELEASE_BRANCH}"; then
+        die "Release branch already exists: ${RELEASE_BRANCH}"
+      fi
+      ;;
+  esac
+}
+
+fetch_base_and_target() {
+  require_env MERGE_COMMIT_SHA
+
+  git fetch --no-tags origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
+  TARGET_SHA="$(git rev-parse --verify "${MERGE_COMMIT_SHA}^{commit}")" || die "Merge commit does not exist locally: ${MERGE_COMMIT_SHA}"
+  BASE_SHA="$(git rev-parse --verify "origin/${PR_BASE_REF}^{commit}")" || die "Base branch does not exist locally: ${PR_BASE_REF}"
+
+  if [[ "${BASE_SHA}" != "${TARGET_SHA}" ]]; then
+    die "Base branch ${PR_BASE_REF} is at ${BASE_SHA}, expected merge commit ${TARGET_SHA}"
+  fi
+}
+
+ensure_release_branch() {
+  case "${EFFECTIVE_RELEASE_KIND}" in
+    patch)
+      remote_ref_exists "refs/heads/${RELEASE_BRANCH}" || die "Patch release branch does not exist: ${RELEASE_BRANCH}"
+      ;;
+    minor|major)
+      local existing_sha
+      existing_sha="$(remote_ref_sha "refs/heads/${RELEASE_BRANCH}")"
+      if [[ -n "${existing_sha}" ]]; then
+        [[ "${existing_sha}" == "${TARGET_SHA}" ]] || die "Release branch ${RELEASE_BRANCH} exists at ${existing_sha}, expected ${TARGET_SHA}"
+        note "Release branch already exists at ${TARGET_SHA}: ${RELEASE_BRANCH}"
+        return
+      fi
+
+      git update-ref "refs/heads/${RELEASE_BRANCH}" "${TARGET_SHA}"
+      git push origin "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
+      note "Created release branch ${RELEASE_BRANCH} at ${TARGET_SHA}"
+      ;;
+  esac
+}
+
+ensure_release_tag() {
+  local existing_commit
+
+  if remote_ref_exists "refs/tags/${TAG}"; then
+    git fetch --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
+    existing_commit="$(git rev-list -n 1 "${TAG}")"
+    [[ "${existing_commit}" == "${TARGET_SHA}" ]] || die "Release tag ${TAG} points to ${existing_commit}, expected ${TARGET_SHA}"
+    note "Release tag already exists at ${TARGET_SHA}: ${TAG}"
+    return
+  fi
+
+  git config user.name "${GIT_COMMITTER_NAME:-github-actions[bot]}"
+  git config user.email "${GIT_COMMITTER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+  git tag -a "${TAG}" "${TARGET_SHA}" -m "Release ${TAG}"
+  git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
+  note "Created release tag ${TAG} at ${TARGET_SHA}"
+}
+
+write_outputs() {
+  [[ -n "${GITHUB_OUTPUT:-}" ]] || return 0
+  {
+    echo "namespace=${NAMESPACE}"
+    echo "tag=${TAG}"
+    echo "release_branch=${RELEASE_BRANCH}"
+    echo "release_kind=${EFFECTIVE_RELEASE_KIND}"
+  } >> "${GITHUB_OUTPUT}"
+}
+
+main() {
+  local mode="${1:-}"
+  case "${mode}" in
+    validate|finalize) ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+
+  parse_release_metadata
+  write_outputs
+
+  if [[ "${mode}" == "validate" ]]; then
+    validate_remote_preconditions
+    note "Validated ${NAMESPACE} ${EFFECTIVE_RELEASE_KIND} release ${TAG}"
+    exit 0
+  fi
+
+  fetch_base_and_target
+  ensure_release_branch
+  ensure_release_tag
+}
+
+main "$@"

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -108,8 +108,12 @@ parse_release_metadata() {
   TAG="$(extract_body_field "Release tag")" || die "PR body is missing 'Release tag: ...'"
   RELEASE_BRANCH="$(extract_body_field "Release branch")" || die "PR body is missing 'Release branch: ...'"
   RELEASE_KIND="$(extract_body_field "Release kind" || true)"
-  # Trim surrounding whitespace and lowercase, since this field may be hand-edited in the PR body.
-  RELEASE_KIND="$(echo "${RELEASE_KIND:-patch}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  RELEASE_KIND="${RELEASE_KIND:-patch}"
+  # Trim leading/trailing whitespace and lowercase (field may be hand-edited in the PR body).
+  # Only outer whitespace is stripped, not internal, so a typo like "min or" still fails loudly.
+  RELEASE_KIND="${RELEASE_KIND#"${RELEASE_KIND%%[![:space:]]*}"}"
+  RELEASE_KIND="${RELEASE_KIND%"${RELEASE_KIND##*[![:space:]]}"}"
+  RELEASE_KIND="$(tr '[:upper:]' '[:lower:]' <<< "${RELEASE_KIND}")"
 
   case "${RELEASE_KIND}" in
     patch|minor|major) ;;

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -234,7 +234,7 @@ ensure_release_tag() {
 
   if remote_ref_exists "refs/tags/${TAG}"; then
     git fetch --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
-    existing_commit="$(git rev-list -n 1 "${TAG}")"
+    existing_commit="$(git rev-list -n 1 "refs/tags/${TAG}")"
     [[ "${existing_commit}" == "${TARGET_SHA}" ]] || die "Release tag ${TAG} points to ${existing_commit}, expected ${TARGET_SHA}"
     note "Release tag already exists at ${TARGET_SHA}: ${TAG}"
     return

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -178,8 +178,8 @@ fetch_base_and_target() {
   TARGET_SHA="$(git rev-parse --verify "${MERGE_COMMIT_SHA}^{commit}")" || die "Merge commit does not exist locally: ${MERGE_COMMIT_SHA}"
   BASE_SHA="$(git rev-parse --verify "origin/${PR_BASE_REF}^{commit}")" || die "Base branch does not exist locally: ${PR_BASE_REF}"
 
-  if [[ "${BASE_SHA}" != "${TARGET_SHA}" ]]; then
-    die "Base branch ${PR_BASE_REF} is at ${BASE_SHA}, expected merge commit ${TARGET_SHA}"
+  if ! git merge-base --is-ancestor "${TARGET_SHA}" "${BASE_SHA}"; then
+    die "Merge commit ${TARGET_SHA} is not reachable from base branch ${PR_BASE_REF}@${BASE_SHA}"
   fi
 }
 

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -17,7 +17,6 @@ Environment:
   PR_BASE_REF            Pull request base branch.
   PR_HEAD_REF            Pull request head branch.
   MERGE_COMMIT_SHA       Required for finalize mode.
-  RELEASE_NAMESPACE      Optional: auto, production, or test. Defaults to auto.
 USAGE
 }
 
@@ -112,38 +111,11 @@ tag_prefixes_for_error() {
 }
 
 resolve_namespace() {
-  local requested="${RELEASE_NAMESPACE:-auto}"
-
-  case "${requested}" in
-    auto)
-      if [[ "${TAG}" == test-v* || "${TAG}" == test/v* || "${RELEASE_BRANCH}" == test-release/* || "${PR_BASE_REF}" == test-main || "${PR_BASE_REF}" == test-release/* ]]; then
-        NAMESPACE="test"
-      else
-        NAMESPACE="production"
-      fi
-      ;;
-    production|test)
-      NAMESPACE="${requested}"
-      ;;
-    *)
-      die "Invalid RELEASE_NAMESPACE: ${requested}"
-      ;;
-  esac
-
-  case "${NAMESPACE}" in
-    production)
-      RELEASE_REF_PREFIX=""
-      TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")")
-      RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
-      MAIN_BRANCH="main"
-      ;;
-    test)
-      RELEASE_REF_PREFIX="test-"
-      TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")" "test/v")
-      RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
-      MAIN_BRANCH="test-main"
-      ;;
-  esac
+  NAMESPACE="production"
+  RELEASE_REF_PREFIX=""
+  TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")")
+  RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
+  MAIN_BRANCH="main"
 }
 
 parse_release_metadata() {
@@ -166,8 +138,8 @@ parse_release_metadata() {
 
   resolve_namespace
 
-  VERSION="$(tag_version)" || die "${NAMESPACE} release tags must start with $(tag_prefixes_for_error): ${TAG}"
-  [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "${NAMESPACE} release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
+  VERSION="$(tag_version)" || die "Release tags must start with $(tag_prefixes_for_error): ${TAG}"
+  [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "Release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
 
   ensure_valid_ref "refs/tags/${TAG}"
   ensure_valid_ref "refs/heads/${RELEASE_BRANCH}"

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -6,6 +6,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=scripts/release-config.sh
 source "${REPO_ROOT}/scripts/release-config.sh"
 
+# Public finalization only ever targets the production namespace.
+readonly NAMESPACE="production"
+readonly TAG_PREFIX="v"
+readonly RELEASE_BRANCH_PREFIX="release/"
+readonly MAIN_BRANCH="main"
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -86,38 +92,8 @@ ensure_valid_ref() {
 }
 
 tag_version() {
-  local prefix
-
-  for prefix in "${TAG_PREFIXES[@]}"; do
-    if [[ "${TAG:0:${#prefix}}" == "${prefix}" ]]; then
-      printf '%s\n' "${TAG:${#prefix}}"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-tag_prefixes_for_error() {
-  local joined="" prefix
-
-  for prefix in "${TAG_PREFIXES[@]}"; do
-    if [[ -z "${joined}" ]]; then
-      joined="${prefix}"
-    else
-      joined="${joined} or ${prefix}"
-    fi
-  done
-
-  printf '%s\n' "${joined}"
-}
-
-resolve_namespace() {
-  NAMESPACE="production"
-  RELEASE_REF_PREFIX=""
-  TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")")
-  RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
-  MAIN_BRANCH="main"
+  [[ "${TAG}" == "${TAG_PREFIX}"* ]] || return 1
+  printf '%s\n' "${TAG#"${TAG_PREFIX}"}"
 }
 
 parse_release_metadata() {
@@ -132,16 +108,15 @@ parse_release_metadata() {
   TAG="$(extract_body_field "Release tag")" || die "PR body is missing 'Release tag: ...'"
   RELEASE_BRANCH="$(extract_body_field "Release branch")" || die "PR body is missing 'Release branch: ...'"
   RELEASE_KIND="$(extract_body_field "Release kind" || true)"
-  RELEASE_KIND="${RELEASE_KIND:-patch}"
+  # Trim surrounding whitespace and lowercase, since this field may be hand-edited in the PR body.
+  RELEASE_KIND="$(echo "${RELEASE_KIND:-patch}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 
   case "${RELEASE_KIND}" in
     patch|minor|major) ;;
     *) die "Invalid Release kind: ${RELEASE_KIND}" ;;
   esac
 
-  resolve_namespace
-
-  VERSION="$(tag_version)" || die "Release tags must start with $(tag_prefixes_for_error): ${TAG}"
+  VERSION="$(tag_version)" || die "Release tags must start with ${TAG_PREFIX}: ${TAG}"
   [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "Release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
 
   ensure_valid_ref "refs/tags/${TAG}"

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=scripts/release-config.sh
+source "${REPO_ROOT}/scripts/release-config.sh"
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -51,12 +56,27 @@ extract_body_field() {
 
 remote_ref_exists() {
   local ref="$1"
-  git ls-remote --exit-code origin "${ref}" >/dev/null 2>&1
+  local output status
+
+  if output="$(git ls-remote --exit-code origin "${ref}" 2>&1)"; then
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ "${status}" -eq 2 ]]; then
+    return 1
+  fi
+
+  die "Unable to query remote ref ${ref}: ${output}"
 }
 
 remote_ref_sha() {
   local ref="$1"
-  git ls-remote origin "${ref}" | awk 'NR == 1 {print $1}'
+  local output
+
+  output="$(git ls-remote origin "${ref}" 2>&1)" || die "Unable to query remote ref ${ref}: ${output}"
+  awk 'NR == 1 {print $1}' <<< "${output}"
 }
 
 ensure_valid_ref() {
@@ -64,12 +84,39 @@ ensure_valid_ref() {
   git check-ref-format "${ref}" >/dev/null 2>&1 || die "Invalid Git ref: ${ref}"
 }
 
+tag_version() {
+  local prefix
+
+  for prefix in "${TAG_PREFIXES[@]}"; do
+    if [[ "${TAG:0:${#prefix}}" == "${prefix}" ]]; then
+      printf '%s\n' "${TAG:${#prefix}}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+tag_prefixes_for_error() {
+  local joined="" prefix
+
+  for prefix in "${TAG_PREFIXES[@]}"; do
+    if [[ -z "${joined}" ]]; then
+      joined="${prefix}"
+    else
+      joined="${joined} or ${prefix}"
+    fi
+  done
+
+  printf '%s\n' "${joined}"
+}
+
 resolve_namespace() {
   local requested="${RELEASE_NAMESPACE:-auto}"
 
   case "${requested}" in
     auto)
-      if [[ "${TAG}" == test/v* || "${RELEASE_BRANCH}" == test-release/* || "${PR_BASE_REF}" == test-main || "${PR_BASE_REF}" == test-release/* ]]; then
+      if [[ "${TAG}" == test-v* || "${TAG}" == test/v* || "${RELEASE_BRANCH}" == test-release/* || "${PR_BASE_REF}" == test-main || "${PR_BASE_REF}" == test-release/* ]]; then
         NAMESPACE="test"
       else
         NAMESPACE="production"
@@ -85,13 +132,15 @@ resolve_namespace() {
 
   case "${NAMESPACE}" in
     production)
-      TAG_PREFIX="v"
-      RELEASE_BRANCH_PREFIX="release/"
+      RELEASE_REF_PREFIX=""
+      TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")")
+      RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
       MAIN_BRANCH="main"
       ;;
     test)
-      TAG_PREFIX="test/v"
-      RELEASE_BRANCH_PREFIX="test-release/"
+      RELEASE_REF_PREFIX="test-"
+      TAG_PREFIXES=("$(release_tag_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")" "test/v")
+      RELEASE_BRANCH_PREFIX="$(release_branch_prefix_from_ref_prefix "${RELEASE_REF_PREFIX}")"
       MAIN_BRANCH="test-main"
       ;;
   esac
@@ -102,7 +151,8 @@ parse_release_metadata() {
   require_env PR_BASE_REF
   require_env PR_HEAD_REF
 
-  [[ "${PR_HEAD_REF}" == sync/copybara-export-* ]] || die "Release finalizer only accepts Copybara export branches"
+  [[ "${PR_HEAD_REF}" =~ ^sync/[A-Za-z0-9._-]+$ ]] || die "Release finalizer only accepts Copybara sync branches"
+  git check-ref-format --branch "${PR_HEAD_REF}" >/dev/null 2>&1 || die "Invalid Copybara sync branch: ${PR_HEAD_REF}"
 
   TAG="$(extract_body_field "Release tag")" || die "PR body is missing 'Release tag: ...'"
   RELEASE_BRANCH="$(extract_body_field "Release branch")" || die "PR body is missing 'Release branch: ...'"
@@ -116,14 +166,13 @@ parse_release_metadata() {
 
   resolve_namespace
 
-  [[ "${TAG}" == "${TAG_PREFIX}"* ]] || die "${NAMESPACE} release tags must start with ${TAG_PREFIX}: ${TAG}"
+  VERSION="$(tag_version)" || die "${NAMESPACE} release tags must start with $(tag_prefixes_for_error): ${TAG}"
   [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "${NAMESPACE} release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
 
   ensure_valid_ref "refs/tags/${TAG}"
   ensure_valid_ref "refs/heads/${RELEASE_BRANCH}"
   ensure_valid_ref "refs/heads/${MAIN_BRANCH}"
 
-  VERSION="${TAG:${#TAG_PREFIX}}"
   if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
     die "Public finalization only supports final SemVer tags, got ${TAG}"
   fi

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -38,6 +38,8 @@ require_env() {
 
 extract_body_field() {
   local label="$1"
+  # awk exits after the first match, so output is always single-line — this prevents
+  # GITHUB_OUTPUT injection if PR_BODY contains a newline embedded in a field value.
   awk -v label="${label}: " '
     index($0, label) == 1 {
       sub(label, "")
@@ -123,6 +125,7 @@ parse_release_metadata() {
   require_env PR_BASE_REF
   require_env PR_HEAD_REF
 
+  # Matches Copybara's sync branch naming convention; update here if the sync workflow changes.
   [[ "${PR_HEAD_REF}" =~ ^sync/[A-Za-z0-9._-]+$ ]] || die "Release finalizer only accepts Copybara sync branches"
   git check-ref-format --branch "${PR_HEAD_REF}" >/dev/null 2>&1 || die "Invalid Copybara sync branch: ${PR_HEAD_REF}"
 
@@ -158,6 +161,7 @@ parse_release_metadata() {
   EFFECTIVE_RELEASE_KIND="${RELEASE_KIND}"
   if [[ "${RELEASE_KIND}" == "patch" && "${PATCH}" == "0" ]]; then
     EFFECTIVE_RELEASE_KIND="minor"
+    note "Release kind promoted from patch to minor for ${TAG} (PATCH=0 means first release on a new branch)"
   fi
 
   case "${EFFECTIVE_RELEASE_KIND}" in
@@ -219,7 +223,7 @@ ensure_release_branch() {
       fi
 
       git update-ref "refs/heads/${RELEASE_BRANCH}" "${TARGET_SHA}"
-      git push origin "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
+      git push origin -- "refs/heads/${RELEASE_BRANCH}:refs/heads/${RELEASE_BRANCH}"
       note "Created release branch ${RELEASE_BRANCH} at ${TARGET_SHA}"
       ;;
   esac
@@ -238,8 +242,8 @@ ensure_release_tag() {
 
   git config user.name "${GIT_COMMITTER_NAME:-github-actions[bot]}"
   git config user.email "${GIT_COMMITTER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
-  git tag -a "${TAG}" "${TARGET_SHA}" -m "Release ${TAG}"
-  git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
+  git tag -a -m "Release ${TAG}" -- "${TAG}" "${TARGET_SHA}"
+  git push origin -- "refs/tags/${TAG}:refs/tags/${TAG}"
   note "Created release tag ${TAG} at ${TARGET_SHA}"
 }
 
@@ -262,7 +266,6 @@ main() {
   esac
 
   parse_release_metadata
-  write_outputs
 
   if [[ "${mode}" == "validate" ]]; then
     validate_remote_preconditions
@@ -273,6 +276,7 @@ main() {
   fetch_base_and_target
   ensure_release_branch
   ensure_release_tag
+  write_outputs
 }
 
 main "$@"

--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-# shellcheck source=scripts/release-config.sh
-source "${REPO_ROOT}/scripts/release-config.sh"
-
 # Public finalization only ever targets the production namespace.
 readonly NAMESPACE="production"
 readonly TAG_PREFIX="v"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -69,26 +69,17 @@ jobs:
         run: |
           SHA="$(git rev-parse HEAD)"
           if [[ "$EVENT_NAME" == "workflow_call" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            RELEASE_TAG="$INPUT_TAG"
-          else
-            RELEASE_TAG=""
-          fi
-          if [[ -n "$RELEASE_TAG" ]]; then
             # shellcheck source=scripts/release-config.sh
             source scripts/release-config.sh
-            if ! image_version="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
-              echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
+            if ! release_docker_image_version_from_tag "$INPUT_TAG" >/dev/null; then
+              echo "::error::Invalid tag format: '$INPUT_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
               exit 1
             fi
-            echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
-          else
-            echo "image_version=" >> "$GITHUB_OUTPUT"
           fi
           {
             echo "full_hash=${SHA}"
             echo "short_hash=${SHA::8}"
             echo "git_version=$(git describe --tags --always --dirty 2>/dev/null || echo 'v0.0.0-unknown')"
-            echo "release_tag=${RELEASE_TAG}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -6,10 +6,13 @@ on:
     branches:
       - main
       - release/*
-  push:
-    tags:
-      - 'v*'
   workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build and publish Docker images for (e.g. v0.6.0)'
+        required: true
+        type: string
+  workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to build and publish Docker images for (e.g. v0.6.0)'
@@ -17,7 +20,7 @@ on:
         type: string
 
 concurrency:
-  group: docker-${{ github.event_name == 'workflow_call' && inputs.tag || github.ref }}
+  group: docker-${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.tag || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -27,8 +30,8 @@ env:
 jobs:
   build:
     if: >-
-      github.event_name == 'push' ||
       github.event_name == 'workflow_call' ||
+      github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'build-docker')
     name: Build ${{ matrix.image }} (${{ matrix.platform }})
     permissions:
@@ -55,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event_name == 'workflow_call' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && format('refs/tags/{0}', inputs.tag) || github.ref }}
           submodules: recursive
 
       - name: Resolve image metadata
@@ -65,10 +68,8 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           SHA="$(git rev-parse HEAD)"
-          if [[ "$EVENT_NAME" == "workflow_call" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_call" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
             RELEASE_TAG="$INPUT_TAG"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            RELEASE_TAG="${GITHUB_REF#refs/tags/}"
           else
             RELEASE_TAG=""
           fi
@@ -122,13 +123,13 @@ jobs:
           path: trivy-results.sarif
 
       - name: Login to Cloudsmith
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/cloudsmith-login
         with:
           registry: ${{ env.REGISTRY }}
 
       - name: Push image by digest
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
           BAKE_METADATA: ${{ steps.build.outputs.metadata }}
@@ -151,7 +152,7 @@ jobs:
           echo "${REGISTRY_DIGEST}" > "/tmp/digests/${MATRIX_IMAGE}/${PLATFORM_SLUG}"
 
       - name: Upload digest
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.image }}-${{ matrix.arch }}
@@ -159,7 +160,7 @@ jobs:
           if-no-files-found: error
 
   manifest:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
+    if: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
     name: Manifest ${{ matrix.image }}
     permissions:
       contents: read
@@ -198,7 +199,7 @@ jobs:
         id: manifest
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_call' && inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           VERSION="${RELEASE_TAG#v}"
           TAG="${IMAGE}:${VERSION}"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -73,9 +73,16 @@ jobs:
           else
             RELEASE_TAG=""
           fi
-          if [[ -n "$RELEASE_TAG" && ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
-            echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
-            exit 1
+          if [[ -n "$RELEASE_TAG" ]]; then
+            # shellcheck source=scripts/release-config.sh
+            source scripts/release-config.sh
+            if ! image_version="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
+              echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3, test-v1.2.3, or test/v1.2.3)"
+              exit 1
+            fi
+            echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_version=" >> "$GITHUB_OUTPUT"
           fi
           {
             echo "full_hash=${SHA}"
@@ -178,7 +185,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          sparse-checkout: .github/actions
+          ref: ${{ format('refs/tags/{0}', inputs.tag) }}
+          sparse-checkout: |
+            .github/actions
+            scripts
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -201,8 +211,15 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          VERSION="${RELEASE_TAG#v}"
-          TAG="${IMAGE}:${VERSION}"
+          # shellcheck source=scripts/release-config.sh
+          source scripts/release-config.sh
+          if ! IMAGE_VERSION="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
+            echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3, test-v1.2.3, or test/v1.2.3)"
+            exit 1
+          fi
+          SHORT_HASH="$(git rev-parse --short=8 HEAD)"
+          TAG="${IMAGE}:${IMAGE_VERSION}"
+          SHA_TAG="${IMAGE}:${IMAGE_VERSION}-${SHORT_HASH}"
 
           # Build digest args from all platform artifacts
           DIGEST_ARGS=()
@@ -216,7 +233,7 @@ jobs:
           fi
 
           # Create and push the manifest list
-          docker buildx imagetools create -t "${TAG}" "${DIGEST_ARGS[@]}"
+          docker buildx imagetools create -t "${TAG}" -t "${SHA_TAG}" "${DIGEST_ARGS[@]}"
 
           MANIFEST_DIGEST=$(docker buildx imagetools inspect "${TAG}" --raw | sha256sum | awk '{print "sha256:"$1}')
           echo "digest=${MANIFEST_DIGEST}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -77,7 +77,7 @@ jobs:
             # shellcheck source=scripts/release-config.sh
             source scripts/release-config.sh
             if ! image_version="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
-              echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3, test-v1.2.3, or test/v1.2.3)"
+              echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
               exit 1
             fi
             echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
@@ -214,7 +214,7 @@ jobs:
           # shellcheck source=scripts/release-config.sh
           source scripts/release-config.sh
           if ! IMAGE_VERSION="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
-            echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3, test-v1.2.3, or test/v1.2.3)"
+            echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
           SHORT_HASH="$(git rev-parse --short=8 HEAD)"

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -217,7 +217,8 @@ jobs:
             echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
-          SHORT_HASH="$(git rev-parse --short=8 HEAD)"
+          SHA="$(git rev-parse HEAD)"
+          SHORT_HASH="${SHA::8}"
           TAG="${IMAGE}:${IMAGE_VERSION}"
           SHA_TAG="${IMAGE}:${IMAGE_VERSION}-${SHORT_HASH}"
 

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -9,9 +9,15 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build and publish Docker images for (e.g. v0.6.0)'
+        required: true
+        type: string
 
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker-${{ github.event_name == 'workflow_call' && inputs.tag || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -22,6 +28,7 @@ jobs:
   build:
     if: >-
       github.event_name == 'push' ||
+      github.event_name == 'workflow_call' ||
       contains(github.event.pull_request.labels.*.name, 'build-docker')
     name: Build ${{ matrix.image }} (${{ matrix.platform }})
     permissions:
@@ -48,13 +55,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.event_name == 'workflow_call' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           submodules: recursive
 
-      - name: Compute short hash
+      - name: Resolve image metadata
         id: vars
         env:
-          SHA: ${{ github.sha }}
-        run: echo "short_hash=${SHA::8}" >> "$GITHUB_OUTPUT"
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          if [[ "$EVENT_NAME" == "workflow_call" ]]; then
+            RELEASE_TAG="$INPUT_TAG"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          else
+            RELEASE_TAG=""
+          fi
+          if [[ -n "$RELEASE_TAG" && ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
+            exit 1
+          fi
+          {
+            echo "full_hash=${SHA}"
+            echo "short_hash=${SHA::8}"
+            echo "git_version=$(git describe --tags --always --dirty 2>/dev/null || echo 'v0.0.0-unknown')"
+            echo "release_tag=${RELEASE_TAG}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -73,8 +100,8 @@ jobs:
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1
           GITHUB_TOKEN: ${{ github.token }}
-          GIT_COMMIT_HASH: ${{ github.sha }}
-          GIT_VERSION: ${{ github.ref_name }}
+          GIT_COMMIT_HASH: ${{ steps.vars.outputs.full_hash }}
+          GIT_VERSION: ${{ steps.vars.outputs.git_version }}
           GIT_SHORT_HASH: ${{ steps.vars.outputs.short_hash }}
 
       - name: Trivy vulnerability scan
@@ -95,13 +122,13 @@ jobs:
           path: trivy-results.sarif
 
       - name: Login to Cloudsmith
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
         uses: ./.github/actions/cloudsmith-login
         with:
           registry: ${{ env.REGISTRY }}
 
       - name: Push image by digest
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
           BAKE_METADATA: ${{ steps.build.outputs.metadata }}
@@ -124,7 +151,7 @@ jobs:
           echo "${REGISTRY_DIGEST}" > "/tmp/digests/${MATRIX_IMAGE}/${PLATFORM_SLUG}"
 
       - name: Upload digest
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.image }}-${{ matrix.arch }}
@@ -132,7 +159,7 @@ jobs:
           if-no-files-found: error
 
   manifest:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' }}
     name: Manifest ${{ matrix.image }}
     permissions:
       contents: read
@@ -171,7 +198,7 @@ jobs:
         id: manifest
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_call' && inputs.tag || github.ref_name }}
         run: |
           VERSION="${RELEASE_TAG#v}"
           TAG="${IMAGE}:${VERSION}"

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -1,0 +1,71 @@
+name: Finalize Public Release
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, closed]
+    branches:
+      - main
+      - test-main
+      - release/**
+      - test-release/**
+
+concurrency:
+  group: public-release-finalizer-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-release-pr:
+    name: Validate release metadata
+    if: >-
+      github.event.action != 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Validate release metadata
+        uses: ./.github/actions/finalize-release
+        with:
+          mode: validate
+          release-namespace: auto
+          pr-body: ${{ github.event.pull_request.body }}
+          pr-base-ref: ${{ github.event.pull_request.base.ref }}
+          pr-head-ref: ${{ github.event.pull_request.head.ref }}
+
+  finalize-release:
+    name: Create release branch and tag
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Create release branch and tag
+        uses: ./.github/actions/finalize-release
+        with:
+          mode: finalize
+          release-namespace: auto
+          pr-body: ${{ github.event.pull_request.body }}
+          pr-base-ref: ${{ github.event.pull_request.base.ref }}
+          pr-head-ref: ${{ github.event.pull_request.head.ref }}
+          merge-commit-sha: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -55,6 +55,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    outputs:
+      namespace: ${{ steps.finalize.outputs.namespace }}
+      tag: ${{ steps.finalize.outputs.tag }}
+      release_branch: ${{ steps.finalize.outputs.release_branch }}
+      release_kind: ${{ steps.finalize.outputs.release_kind }}
     steps:
       - name: Checkout base branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -63,6 +68,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create release branch and tag
+        id: finalize
         uses: ./.github/actions/finalize-release
         with:
           mode: finalize
@@ -71,3 +77,26 @@ jobs:
           pr-base-ref: ${{ github.event.pull_request.base.ref }}
           pr-head-ref: ${{ github.event.pull_request.head.ref }}
           merge-commit-sha: ${{ github.event.pull_request.merge_commit_sha }}
+
+  release-binaries:
+    name: Release binaries
+    needs: finalize-release
+    if: needs.finalize-release.outputs.namespace == 'production'
+    uses: ./.github/workflows/release-binaries.yaml
+    with:
+      tag: ${{ needs.finalize-release.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: write
+
+  release-docker:
+    name: Release Docker images
+    needs: finalize-release
+    if: needs.finalize-release.outputs.namespace == 'production'
+    uses: ./.github/workflows/build-docker.yaml
+    with:
+      tag: ${{ needs.finalize-release.outputs.tag }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -5,9 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled, closed]
     branches:
       - main
-      - test-main
       - release/**
-      - test-release/**
 
 concurrency:
   group: public-release-finalizer-${{ github.event.pull_request.number }}
@@ -30,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
@@ -39,7 +37,6 @@ jobs:
         uses: ./.github/actions/finalize-release
         with:
           mode: validate
-          release-namespace: auto
           pr-body: ${{ github.event.pull_request.body }}
           pr-base-ref: ${{ github.event.pull_request.base.ref }}
           pr-head-ref: ${{ github.event.pull_request.head.ref }}
@@ -64,7 +61,7 @@ jobs:
       release_kind: ${{ steps.finalize.outputs.release_kind }}
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
@@ -74,7 +71,6 @@ jobs:
         uses: ./.github/actions/finalize-release
         with:
           mode: finalize
-          release-namespace: auto
           pr-body: ${{ github.event.pull_request.body }}
           pr-base-ref: ${{ github.event.pull_request.base.ref }}
           pr-head-ref: ${{ github.event.pull_request.head.ref }}
@@ -83,7 +79,7 @@ jobs:
   release-binaries:
     name: Release binaries
     needs: finalize-release
-    if: needs.finalize-release.outputs.namespace == 'production'
+    if: needs.finalize-release.result == 'success'
     uses: ./.github/workflows/release-binaries.yaml
     with:
       tag: ${{ needs.finalize-release.outputs.tag }}

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -24,6 +24,7 @@ jobs:
       github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.repo.fork == false &&
       startsWith(github.event.pull_request.head.ref, 'sync/')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -49,6 +50,7 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.repo.fork == false &&
       startsWith(github.event.pull_request.head.ref, 'sync/')
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -95,7 +95,11 @@ jobs:
     name: Release Docker images
     needs: finalize-release
     if: needs.finalize-release.outputs.namespace == 'production'
-    uses: ./.github/workflows/build-docker.yaml
+    # Pinned to main (not a local `./` reference) so job_workflow_ref is always
+    # main regardless of whether this run started on a release/* branch (patch
+    # releases) or main (minor/major releases). Keep in sync with the Cloudsmith
+    # OIDC trust condition in crcl-main/terraform-cicd's accounts/ops/cloudsmith/oidc.tf.
+    uses: circlefin/arc-node/.github/workflows/build-docker.yaml@main
     with:
       tag: ${{ needs.finalize-release.outputs.tag }}
     permissions:

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -95,10 +95,6 @@ jobs:
     name: Release Docker images
     needs: finalize-release
     if: needs.finalize-release.outputs.namespace == 'production'
-    # Pinned to main (not a local `./` reference) so job_workflow_ref is always
-    # main regardless of whether this run started on a release/* branch (patch
-    # releases) or main (minor/major releases). Keep in sync with the Cloudsmith
-    # OIDC trust condition in crcl-main/terraform-cicd's accounts/ops/cloudsmith/oidc.tf.
     uses: circlefin/arc-node/.github/workflows/build-docker.yaml@main
     with:
       tag: ${{ needs.finalize-release.outputs.tag }}

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -24,7 +24,7 @@ jobs:
       github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
+      startsWith(github.event.pull_request.head.ref, 'sync/')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -49,7 +49,7 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
+      startsWith(github.event.pull_request.head.ref, 'sync/')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -23,6 +23,7 @@ jobs:
     if: >-
       github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -47,6 +48,7 @@ jobs:
     if: >-
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'sync/copybara-export-')
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -90,15 +90,3 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
-
-  release-docker:
-    name: Release Docker images
-    needs: finalize-release
-    if: needs.finalize-release.outputs.namespace == 'production'
-    uses: circlefin/arc-node/.github/workflows/build-docker.yaml@main
-    with:
-      tag: ${{ needs.finalize-release.outputs.tag }}
-    permissions:
-      attestations: write
-      contents: read
-      id-token: write

--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -44,6 +44,7 @@ jobs:
   finalize-release:
     name: Create release branch and tag
     if: >-
+      github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -86,3 +87,23 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  remind-docker-publish:
+    name: Remind to publish Docker images
+    needs: finalize-release
+    if: needs.finalize-release.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment reminder on release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.finalize-release.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Docker publishing can't be chained automatically (Cloudsmith OIDC can't trust
+          # a release/* wildcard claim), so this is a reminder, not automation.
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "Release \`${TAG}\` finalized. Docker images are **not** published automatically — trigger the \`Build Docker Images\` workflow manually via \`workflow_dispatch\` with tag \`${TAG}\` to publish them."

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -19,10 +19,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
-concurrency:
-  group: release-binaries-${{ inputs.tag || github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Build (${{ matrix.target }})
@@ -49,12 +45,14 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          VERSION="$INPUT_TAG"
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
-            echo "::error::Invalid tag format: '$VERSION' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
+          TAG="$INPUT_TAG"
+          if [[ ! "$TAG" =~ (^|[-/])(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or test-v1.2.3)"
             exit 1
           fi
+          VERSION="${BASH_REMATCH[2]}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset_tag=${TAG//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -111,7 +109,7 @@ jobs:
 
       - name: Package release assets
         env:
-          TAG: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.asset_tag }}
           TARGET: ${{ matrix.target }}
         run: ./scripts/release-package.sh "$TAG" "$TARGET"
 
@@ -162,6 +160,9 @@ jobs:
     needs: sign
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    concurrency:
+      group: release-binaries-publish-${{ inputs.tag }}
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -171,12 +172,13 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           TAG="$INPUT_TAG"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
-            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
+          if [[ ! "$TAG" =~ (^|[-/])(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or test-v1.2.3)"
             exit 1
           fi
+          VERSION="${BASH_REMATCH[2]}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
@@ -202,9 +204,16 @@ jobs:
             edit_args+=(--prerelease=true)
           fi
 
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "::error::Release ${TAG} already exists; delete the existing draft/release before rerunning"
-            exit 1
+          if release_is_draft="$(gh release view "${TAG}" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+            if [[ "$release_is_draft" != "true" ]]; then
+              echo "::error::Release ${TAG} is already published; refusing to replace public assets"
+              exit 1
+            fi
+
+            echo "::notice::Draft release ${TAG} already exists; replacing draft release assets"
+            gh release upload "${TAG}" release-assets/* --clobber
+            gh release edit "${TAG}" "${edit_args[@]}"
+            exit 0
           fi
 
           gh release create "${TAG}" "${create_args[@]}"

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -50,12 +50,10 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           TAG="$INPUT_TAG"
-          if [[ ! "$TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
             echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
-          VERSION="${BASH_REMATCH[1]}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "asset_tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
@@ -164,9 +162,6 @@ jobs:
     needs: sign
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    concurrency:
-      group: release-binaries-publish-${{ inputs.tag }}
-      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -176,13 +171,12 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           TAG="$INPUT_TAG"
-          if [[ ! "$TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
             echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
-          VERSION="${BASH_REMATCH[1]}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-binaries-${{ inputs.tag }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -46,13 +50,13 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           TAG="$INPUT_TAG"
-          if [[ ! "$TAG" =~ (^|[-/])(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
-            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or test-v1.2.3)"
+          if [[ ! "$TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
-          VERSION="${BASH_REMATCH[2]}"
+          VERSION="${BASH_REMATCH[1]}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "asset_tag=${TAG//\//-}" >> "$GITHUB_OUTPUT"
+          echo "asset_tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -172,11 +176,11 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           TAG="$INPUT_TAG"
-          if [[ ! "$TAG" =~ (^|[-/])(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
-            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or test-v1.2.3)"
+          if [[ ! "$TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?)$ ]]; then
+            echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
-          VERSION="${BASH_REMATCH[2]}"
+          VERSION="${BASH_REMATCH[1]}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,9 +1,6 @@
 name: Release Binaries
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_call:
     inputs:
       tag:
@@ -50,17 +47,9 @@ jobs:
       - name: Resolve artifact version
         id: version
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
-            VERSION="$INPUT_TAG"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            echo "::error::Unsupported release trigger: $EVENT_NAME $GITHUB_REF"
-            exit 1
-          fi
+          VERSION="$INPUT_TAG"
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
             echo "::error::Invalid tag format: '$VERSION' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
@@ -70,7 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ format('refs/tags/{0}', inputs.tag) }}
           submodules: recursive
 
       - name: Install Linux system dependencies
@@ -171,7 +160,6 @@ jobs:
   release:
     name: Create Release
     needs: sign
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -180,17 +168,9 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
-            echo "::error::Unsupported release trigger: $EVENT_NAME $GITHUB_REF"
-            exit 1
-          fi
+          TAG="$INPUT_TAG"
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
             echo "::error::Invalid tag format: '$TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build and release (e.g. v0.6.0)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -47,7 +53,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
             VERSION="$INPUT_TAG"
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
@@ -64,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && format('refs/tags/{0}', inputs.tag) || github.ref }}
           submodules: recursive
 
       - name: Install Linux system dependencies
@@ -165,7 +171,7 @@ jobs:
   release:
     name: Create Release
     needs: sign
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -177,7 +183,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
             TAG="$INPUT_TAG"
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -14,20 +14,16 @@ release_branch_prefix_from_ref_prefix() {
 
 release_docker_image_version_from_tag() {
   local tag="$1"
-  local namespace_prefix
   local version
-  local image_version
 
-  if [[ ! "${tag}" =~ ^([A-Za-z0-9._/-]*[-/])?v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?)$ ]]; then
+  if [[ ! "${tag}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?)$ ]]; then
     return 1
   fi
 
-  namespace_prefix="${BASH_REMATCH[1]:-}"
-  version="${BASH_REMATCH[2]}"
-  image_version="${namespace_prefix//\//-}${version}"
-  if [[ ! "${image_version}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  version="${BASH_REMATCH[1]}"
+  if [[ ! "${version}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
     return 1
   fi
 
-  printf '%s\n' "${image_version}"
+  printf '%s\n' "${version}"
 }

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
 
-release_tag_prefix_from_ref_prefix() {
-  local ref_prefix="${1:-}"
-
-  printf '%sv\n' "${ref_prefix}"
-}
-
-release_branch_prefix_from_ref_prefix() {
-  local ref_prefix="${1:-}"
-
-  printf '%srelease/\n' "${ref_prefix}"
-}
-
 release_docker_image_version_from_tag() {
   local tag="$1"
   local version

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -14,13 +14,17 @@ release_branch_prefix_from_ref_prefix() {
 
 release_docker_image_version_from_tag() {
   local tag="$1"
+  local namespace_prefix
+  local version
   local image_version
 
-  if [[ ! "${tag}" =~ ^([A-Za-z0-9._/-]*[-/])?v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+  if [[ ! "${tag}" =~ ^([A-Za-z0-9._/-]*[-/])?v([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?)$ ]]; then
     return 1
   fi
 
-  image_version="${tag//\//-}"
+  namespace_prefix="${BASH_REMATCH[1]:-}"
+  version="${BASH_REMATCH[2]}"
+  image_version="${namespace_prefix//\//-}${version}"
   if [[ ! "${image_version}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
     return 1
   fi

--- a/scripts/release-config.sh
+++ b/scripts/release-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+release_tag_prefix_from_ref_prefix() {
+  local ref_prefix="${1:-}"
+
+  printf '%sv\n' "${ref_prefix}"
+}
+
+release_branch_prefix_from_ref_prefix() {
+  local ref_prefix="${1:-}"
+
+  printf '%srelease/\n' "${ref_prefix}"
+}
+
+release_docker_image_version_from_tag() {
+  local tag="$1"
+  local image_version
+
+  if [[ ! "${tag}" =~ ^([A-Za-z0-9._/-]*[-/])?v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+    return 1
+  fi
+
+  image_version="${tag//\//-}"
+  if [[ ! "${image_version}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${image_version}"
+}


### PR DESCRIPTION
## Summary

Adds the public-side release finalizer automation for Arc Node:

- validates merged release PRs before finalization
- creates or updates the public release branch for \`vX.Y.0\` releases
- creates final public release tags
- requires the PR to carry the \`release\` label before finalization runs
- chains production final tags into the existing binary release workflow
- keeps binary artifact publisher manually callable from the Actions UI with an explicit tag
- artifact publishing no longer relies on \`v*\` tag-push triggers, avoiding duplicate publishes when the finalizer creates a tag

## Safety

- The workflow only finalizes after PR merge.
- It ignores fork-origin PRs and only finalizes branches from this repository.
- It only accepts \`sync/*\` Copybara branches with Git-valid branch names, matching the private handoff output such as \`sync/v0_8_0\`.
- Only \`v*\` production tags are accepted; the finalizer targets \`main\` and \`release/*\` branches only.
- Binary publishing only runs on a successful finalize, not on test or dry-run triggers.

## Validation

- \`bash -n .github/scripts/finalize-release.sh scripts/release-config.sh\`
- \`actionlint .github/workflows/finalize-release.yaml .github/workflows/release-binaries.yaml .github/workflows/build-docker.yaml\`
- \`git diff --check\`
- Docker tag helper smoke test for \`v0.8.0\` and \`v1.2.3-rc.1\`; confirms \`test-v0.8.0\` and \`test/v0.8.0\` are rejected
- public finalizer validation smoke for \`sync/v0_8_1\` branch shape
- invalid Copybara branch rejection smoke for \`sync/bad..branch\`