### PR TITLE
chore: add Arc consensus builder modifier

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -7,10 +7,25 @@ Each bullet is prefixed with a flag identifying the kind of breaking change:
 - `[CLI]` -- CLI flag added, renamed, removed, or made required.
 - `[Config]` -- default value, environment variable, or manifest field change.
 - `[Format]` -- log, metric label, or serialized output format change that breaks parsers.
+- `[API]` -- public Rust API change that can break downstream crates.
 
 Entries are split by audience. A change appears under `### For Validators` when validator-mode operation must change; otherwise it appears under `### For Node Operators`. A change requiring both audiences to act appears in both sections (rare).
+Rust API compatibility changes appear under `### For Rust API Consumers`.
 
 Compare and release-notes links resolve once the corresponding tag is published at [`circlefin/arc-node`](https://github.com/circlefin/arc-node).
+
+## [Unreleased]
+
+### For Rust API Consumers
+
+- **[API] `ArcConsensusBuilder` is no longer `Clone` or `Copy`.**
+  - Old (`v0.7.2`): `ArcConsensusBuilder` derived `Clone` and `Copy`, so
+    downstream Rust code could duplicate the builder after construction.
+  - New (next release): the builder can hold a `Box<dyn FnOnce + Send + 'static>`
+    consensus modifier and is therefore move-only.
+  - Code that cloned or copied the builder must construct a fresh
+    `ArcConsensusBuilder::default()` or finish applying builder configuration
+    before moving it into the node builder.
 
 ## [v0.7.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to arc-node are documented in this file.
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **[API] `ArcConsensusBuilder` is no longer `Clone` or `Copy`.** The builder
+  can now hold a one-shot consensus modifier closure, so downstream Rust code
+  that cloned or copied the builder must construct a fresh builder or finish
+  configuring it before moving it into the node builder. See
+  [BREAKING_CHANGES.md](./BREAKING_CHANGES.md#unreleased) for migration
+  details.
+
 ## [v0.7.2]
 
 **Changes:** [v0.7.1...v0.7.2](https://github.com/circlefin/arc-node/compare/v0.7.1...v0.7.2) -- [release notes](https://github.com/circlefin/arc-node/releases/tag/v0.7.2)

--- a/crates/evm-node/src/node.rs
+++ b/crates/evm-node/src/node.rs
@@ -940,6 +940,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "consensus modifier already set")]
     fn arc_consensus_builder_panics_on_double_modifier_in_debug() {
         let _builder = ArcConsensusBuilder::default()

--- a/crates/evm-node/src/node.rs
+++ b/crates/evm-node/src/node.rs
@@ -670,17 +670,26 @@ impl std::fmt::Debug for ArcConsensusBuilder {
 impl ArcConsensusBuilder {
     /// Returns a builder that applies `modify_consensus` after constructing the
     /// default [`ArcConsensus`].
+    ///
+    /// Calling this more than once replaces the previous modifier. To apply
+    /// multiple transformations, compose them into one closure before passing it
+    /// to this method.
     pub fn with_consensus_modifier<F>(mut self, modify_consensus: F) -> Self
     where
         F: FnOnce(Arc<ArcConsensus<ArcChainSpec>>) -> eyre::Result<Arc<ArcConsensus<ArcChainSpec>>>
             + Send
             + 'static,
     {
+        debug_assert!(
+            self.modify_consensus.is_none(),
+            "consensus modifier already set; compose modifiers before passing them to ArcConsensusBuilder"
+        );
         self.modify_consensus = Some(Box::new(modify_consensus));
         self
     }
 
-    fn apply_consensus_modifier(
+    /// Applies the configured modifier to a constructed consensus instance.
+    pub(crate) fn apply_consensus_modifier(
         self,
         consensus: Arc<ArcConsensus<ArcChainSpec>>,
     ) -> eyre::Result<Arc<ArcConsensus<ArcChainSpec>>> {
@@ -928,5 +937,13 @@ mod tests {
 
         assert!(called.load(Ordering::Relaxed));
         assert!(Arc::ptr_eq(&modified, &consensus));
+    }
+
+    #[test]
+    #[should_panic(expected = "consensus modifier already set")]
+    fn arc_consensus_builder_panics_on_double_modifier_in_debug() {
+        let _builder = ArcConsensusBuilder::default()
+            .with_consensus_modifier(Ok)
+            .with_consensus_modifier(Ok);
     }
 }

--- a/crates/evm-node/src/node.rs
+++ b/crates/evm-node/src/node.rs
@@ -647,10 +647,48 @@ where
     }
 }
 
+type ArcConsensusModifier = Box<
+    dyn FnOnce(Arc<ArcConsensus<ArcChainSpec>>) -> eyre::Result<Arc<ArcConsensus<ArcChainSpec>>>
+        + Send
+        + 'static,
+>;
+
 /// A basic Arc consensus builder.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default)]
 pub struct ArcConsensusBuilder {
-    // TODO add closure to modify consensus
+    modify_consensus: Option<ArcConsensusModifier>,
+}
+
+impl std::fmt::Debug for ArcConsensusBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArcConsensusBuilder")
+            .field("modify_consensus", &self.modify_consensus.is_some())
+            .finish()
+    }
+}
+
+impl ArcConsensusBuilder {
+    /// Returns a builder that applies `modify_consensus` after constructing the
+    /// default [`ArcConsensus`].
+    pub fn with_consensus_modifier<F>(mut self, modify_consensus: F) -> Self
+    where
+        F: FnOnce(Arc<ArcConsensus<ArcChainSpec>>) -> eyre::Result<Arc<ArcConsensus<ArcChainSpec>>>
+            + Send
+            + 'static,
+    {
+        self.modify_consensus = Some(Box::new(modify_consensus));
+        self
+    }
+
+    fn apply_consensus_modifier(
+        self,
+        consensus: Arc<ArcConsensus<ArcChainSpec>>,
+    ) -> eyre::Result<Arc<ArcConsensus<ArcChainSpec>>> {
+        match self.modify_consensus {
+            Some(modify_consensus) => modify_consensus(consensus),
+            None => Ok(consensus),
+        }
+    }
 }
 
 impl<Node> ConsensusBuilder<Node> for ArcConsensusBuilder
@@ -660,7 +698,7 @@ where
     type Consensus = Arc<ArcConsensus<<Node::Types as NodeTypes>::ChainSpec>>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        Ok(Arc::new(ArcConsensus::new(ctx.chain_spec())))
+        self.apply_consensus_modifier(Arc::new(ArcConsensus::new(ctx.chain_spec())))
     }
 }
 
@@ -868,5 +906,27 @@ mod tests {
         let builder =
             ArcNetworkBuilder::default().with_rebroadcast_interval(std::time::Duration::ZERO);
         assert!(builder.rebroadcast_interval.is_zero());
+    }
+
+    #[test]
+    fn arc_consensus_builder_applies_modifier() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_for_modifier = called.clone();
+        let consensus = Arc::new(ArcConsensus::new(
+            arc_execution_config::chainspec::LOCAL_DEV.clone(),
+        ));
+
+        let modified = ArcConsensusBuilder::default()
+            .with_consensus_modifier(move |consensus| {
+                called_for_modifier.store(true, Ordering::Relaxed);
+                Ok(consensus)
+            })
+            .apply_consensus_modifier(consensus.clone())
+            .expect("modifier should succeed");
+
+        assert!(called.load(Ordering::Relaxed));
+        assert!(Arc::ptr_eq(&modified, &consensus));
     }
 }


### PR DESCRIPTION
## Summary

- Adds an optional `ArcConsensusBuilder` consensus modifier closure.
- Keeps the default `ArcConsensus::new(ctx.chain_spec())` construction path intact.
- Adds unit coverage that verifies the modifier is invoked, its returned consensus is used, and accidental double modifier registration is caught in debug builds.
- Documents the resulting `ArcConsensusBuilder` `Clone`/`Copy` removal as an unreleased breaking Rust API change.

## API compatibility note

This intentionally removes `Clone` and `Copy` from the public `ArcConsensusBuilder` type. `ArcConsensusBuilder` shipped in `v0.7.2` as a public type with both derives, so this is a semver-breaking Rust API change for downstream callers that clone or copy the builder.

The derive removal is required because the builder can now hold a `Box<dyn FnOnce + Send + 'static>` modifier, and that modifier cannot be cloned or copied. The migration note is recorded in `CHANGELOG.md` under `Unreleased` and in `BREAKING_CHANGES.md` under `For Rust API Consumers`.

Fixes #162.

## Verification

- Duplicate gate: PASS (`.context/pre-pr-gates/circlefin-arc-node-162-20260621T153749Z.md`)
- `npx prettier --check CHANGELOG.md BREAKING_CHANGES.md`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p arc-evm-node arc_consensus_builder_panics_on_double_modifier_in_debug`
- `cargo test -p arc-evm-node --release arc_consensus_builder_panics_on_double_modifier_in_debug`
- Earlier code-path verification before the docs-only follow-up:
  - `cargo test -p arc-evm-node` (75 passed)
  - `cargo clippy -p arc-evm-node --all-targets -- -D warnings`
