### PR TITLE
fix: saturate Fin sequence arithmetic in proposal-part streaming

### DIFF
--- a/crates/malachite-app/src/streaming.rs
+++ b/crates/malachite-app/src/streaming.rs
@@ -280,11 +280,16 @@ impl StreamState {
             // If we have received the fin message, we can determine when we will be done.
             // We are done if we have already received all messages from 0 to fin.sequence,
             // included. That is to say, if we have received `fin.sequence + 1` messages.
-            // Sequence is a u64 protocol field; on 64-bit targets usize == u64.
-            // The +1 cannot overflow because MAX_MESSAGES_PER_STREAM << u64::MAX.
-            #[allow(clippy::cast_possible_truncation, clippy::arithmetic_side_effects)]
+            //
+            // `msg.sequence` is an unvalidated u64 straight off the wire, so a
+            // malicious peer can set it to `u64::MAX`. `as usize + 1` would then
+            // overflow: panic under debug-assertions, wrap to 0 in release. Use a
+            // saturating add so the worst case is `usize::MAX` (an unreachable
+            // completion target the stream is later evicted for), never a panic
+            // or a spurious wrap-to-zero.
+            #[allow(clippy::cast_possible_truncation)]
             {
-                self.expected_messages = msg.sequence as usize + 1;
+                self.expected_messages = (msg.sequence as usize).saturating_add(1);
             }
         }
 

--- a/crates/malachite-app/src/streaming.rs
+++ b/crates/malachite-app/src/streaming.rs
@@ -287,6 +287,13 @@ impl StreamState {
             // saturating add so the worst case is `usize::MAX` (an unreachable
             // completion target the stream is later evicted for), never a panic
             // or a spurious wrap-to-zero.
+            //
+            // The retained truncation allow assumes a 64-bit target, where
+            // `usize == u64` and the cast is lossless. On a 32-bit target the
+            // cast would truncate before the saturating add, letting a peer
+            // pick a small-but-wrong completion target; the stream would still
+            // be bounded and evicted, but node deployments are 64-bit and this
+            // code relies on that.
             #[allow(clippy::cast_possible_truncation)]
             {
                 self.expected_messages = (msg.sequence as usize).saturating_add(1);
@@ -754,6 +761,29 @@ mod tests {
             "Stream should not be complete after one message"
         );
         assert_eq!(map.streams.len(), 1, "Map should contain one active stream");
+    }
+
+    #[test]
+    fn test_fin_with_max_sequence_does_not_overflow() {
+        let peer_1 = PeerId::random();
+        let stream_1 = make_stream_id(101);
+
+        let mut map = PartStreamsMap::new(Height::new(1), NUM_VALIDATORS);
+        let init_msg = make_message(&stream_1, 0, make_init_part());
+        // A malicious peer can put any u64 in `sequence`. Before the saturating
+        // add, `sequence as usize + 1` panicked here under debug assertions.
+        let fin_msg = make_fin_message(&stream_1, u64::MAX);
+
+        assert!(map.must_insert(peer_1, init_msg).is_none());
+        assert!(
+            map.must_insert(peer_1, fin_msg).is_none(),
+            "Stream must not complete on a bogus Fin sequence"
+        );
+        assert_eq!(
+            map.streams.len(),
+            1,
+            "Stream should stay pending until evicted, not complete or disappear"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`StreamState::insert` in the consensus proposal-part streaming layer
computed a stream's expected message count from the Fin message's
`sequence` field as `msg.sequence as usize + 1`. `sequence` is an
unvalidated `u64` decoded straight off the gossip wire
(`crates/types/src/codec/proto.rs` — `sequence: proto.sequence`, no
bound-check), and `PartStreamsMap::insert` applies no upper bound on it
before reaching this arithmetic. A peer on the consensus gossip topic can
therefore send a Fin part for the current height with `sequence =
u64::MAX` and drive the `+ 1` to overflow:

- **debug / test builds** (overflow-checks on): panic → node crash.
- **release builds** (overflow-checks off): wraps to `0`.

Release builds are *incidentally* safe today: the later
`buffer.len() == expected_messages` completion check never matches a
wrapped-to-zero target, so the stream stays `Incomplete` and is evicted
by the age/limit sweep. No crash, no unbounded memory (already capped by
`MAX_MESSAGES_PER_STREAM`). The safety rested on wrapping behaviour
rather than intent, and the old comment asserted a false invariant — it
claimed the `+ 1` "cannot overflow because MAX_MESSAGES_PER_STREAM <<
u64::MAX", but `expected_messages` is assigned from the unbounded
`msg.sequence`, not from the bounded `message_count`.

## Change

- Use `saturating_add(1)`: worst case is `usize::MAX`, an unreachable
  completion target the stream is evicted for — never a panic or a silent
  wrap-to-zero.
- Rewrite the comment to describe the actual (peer-controlled, unbounded)
  source of `sequence`.
- Drop the now-unnecessary `clippy::arithmetic_side_effects` allow, since
  the arithmetic is checked.

## Impact

Eliminates a remotely reachable panic in debug/test builds and removes
release builds' latent reliance on wrap-to-zero. No behavioural change on
valid streams (`sequence` values are `< MAX_MESSAGES_PER_STREAM` in
practice). No public API or wire-format change; the touched method is
module-private and `PartStreamsMap::insert`'s signature is unchanged.

## Test plan

- [x] `cargo build -p arc-node-consensus` — clean
- [x] `cargo test -p arc-node-consensus streaming` — 46 passed, 0 failed
      (includes property tests for per-stream / total stream limits),
      run under debug-assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
