### PR TITLE
docs: fix Arc Testnet version table and document v0.7.x breaking changes for DApp developers

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,11 +22,12 @@ Consult the table below to confirm which version to run for each network.
 > **Breaking changes for DApp developers.** Upgrading your target node to v0.7.2 affects
 > applications, not just node operators:
 >
-> - `eth_call` / `eth_estimateGas` gas cap default lowered from 50M to 30M. Calls that
->   need more than 30M gas fail unless the node raises `--rpc.gascap`.
+> - `eth_call` / `eth_estimateGas` gas cap default lowered from 50M to 30M. Calls or
+>   simulations that previously relied on the higher cap will fail. Node operators can
+>   raise the limit with `--rpc.gascap`; DApps should optimize calls to stay within 30M.
 > - JSON-RPC batch requests are capped at 100 entries by default. Oversized batches are
->   rejected with error `-32600` before any entry runs. Clients with a large query
->   fan-out (e.g. viem's default batch transport) should stay under the cap.
+>   rejected with error `-32600` before any entry runs. Clients with JSON-RPC batching
+>   enabled should keep batch size at or under 100.
 > - Precompile gas accounting changed across v0.7.x (EIP-2929 warm/cold pricing on
 >   precompile account loads in v0.7.0, gas charging order in v0.7.2). Re-estimate gas
 >   against an updated node instead of reusing cached or hardcoded values.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,22 @@ Consult the table below to confirm which version to run for each network.
 |-------------|---------|
 | Arc Testnet | v0.7.2  |
 
+
+> [!IMPORTANT]
+> **Breaking changes for DApp developers.** Upgrading your target node to v0.7.2 affects
+> applications, not just node operators:
+>
+> - `eth_call` / `eth_estimateGas` gas cap default lowered from 50M to 30M. Calls that
+>   need more than 30M gas fail unless the node raises `--rpc.gascap`.
+> - JSON-RPC batch requests are capped at 100 entries by default. Oversized batches are
+>   rejected with error `-32600` before any entry runs. Clients with a large query
+>   fan-out (e.g. viem's default batch transport) should stay under the cap.
+> - Precompile gas accounting changed across v0.7.x (EIP-2929 warm/cold pricing on
+>   precompile account loads in v0.7.0, gas charging order in v0.7.2). Re-estimate gas
+>   against an updated node instead of reusing cached or hardcoded values.
+>
+> See [BREAKING_CHANGES.md](../BREAKING_CHANGES.md#v072) for details.
+
 ## Pre-built Binary
 
 This repository includes `arcup`, a script that installs Arc node binaries

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ Consult the table below to confirm which version to run for each network.
 
 | Network     | Version |
 |-------------|---------|
-| Arc Testnet | v0.6.0  |
+| Arc Testnet | v0.7.2  |
 
 ## Pre-built Binary
 
@@ -61,7 +61,7 @@ source "$ARC_HOME/env"
 To install a specific version, run `arcup` with `--install`:
 
 ```sh
-arcup --install v0.6.0
+arcup --install v0.7.2
 ```
 
 Next, verify that the three Arc binaries are installed:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,11 +15,11 @@ Consult the table below to confirm which version to run for each network.
 
 | Network     | Version |
 |-------------|---------|
-| Arc Testnet | v0.7.2  |
+| Arc Testnet | v0.7.3  |
 
 
 > [!IMPORTANT]
-> **Breaking changes for DApp developers.** Upgrading your target node to v0.7.2 affects
+> **Breaking changes for DApp developers.** Upgrading your target node from v0.6.0 to v0.7.3 affects
 > applications, not just node operators:
 >
 > - `eth_call` / `eth_estimateGas` gas cap default lowered from 50M to 30M. Calls or
@@ -78,7 +78,7 @@ source "$ARC_HOME/env"
 To install a specific version, run `arcup` with `--install`:
 
 ```sh
-arcup --install v0.7.2
+arcup --install v0.7.3
 ```
 
 Next, verify that the three Arc binaries are installed:


### PR DESCRIPTION
docs/installation.md still lists v0.6.0 as the Arc Testnet version (table and the arcup --install example). Per CHANGELOG.md, testnet node operators must use v0.7.2 since the Zero7 activation on 2026-06-18 ('Earlier versions are not supported'), and v0.7.2 is the latest published release. A new operator following the current table would install an unsupported version. Updated both references to v0.7.2.