### PR TITLE
docs: clarify public-api warning behavior

### DIFF
--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -450,8 +450,9 @@ prohibited: `txpool`, `debug`, `trace`, `admin`, `flashbots`, `mev`, `ots`.
 
 The `--public-api` flag enforces pending-transaction hiding, but it does not
 rewrite or reject `--http.api` / `--ws.api` selections. It warns at startup if
-either selection exposes namespaces outside the safe set, so operators must
-still configure public endpoints with only the safe namespaces above.
+either selection exposes namespaces outside the safe set, and the node continues
+to serve those namespaces. Operators must still configure public endpoints with
+only the safe namespaces above.
 
 To verify, call `rpc_modules`:
 

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -448,9 +448,10 @@ prohibited: `txpool`, `debug`, `trace`, `admin`, `flashbots`, `mev`, `ots`.
 --public-api
 ```
 
-The `--public-api` flag enforces these restrictions at runtime: it hides
-pending-transaction RPCs and warns at startup if `--http.api` or `--ws.api`
-exposes namespaces outside the safe set.
+The `--public-api` flag enforces pending-transaction hiding, but it does not
+rewrite or reject `--http.api` / `--ws.api` selections. It warns at startup if
+either selection exposes namespaces outside the safe set, so operators must
+still configure public endpoints with only the safe namespaces above.
 
 To verify, call `rpc_modules`:
 


### PR DESCRIPTION
## Summary
- clarify that `--public-api` enforces pending-transaction hiding, but does not rewrite or reject `--http.api` / `--ws.api` selections
- make it explicit that unsafe namespace selections only produce a startup warning and the node continues to serve those namespaces
- remind operators that public endpoints must still be configured with only the safe RPC namespaces

## Why
The previous wording said `--public-api` enforced the public RPC restrictions at runtime. In code, unsafe namespace selections only trigger `warn_if_public_api_unsafe`, so the docs could imply stronger protection than the node actually applies.

Relevant code:
- https://github.com/circlefin/arc-node/blob/main/crates/node/src/main.rs#L426-L436
- https://github.com/circlefin/arc-node/blob/main/crates/node/src/main.rs#L578-L582

## Testing
- `git diff --check`