### PR TITLE
fix: source release-config.sh from main in build-docker.yaml

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -60,6 +60,7 @@ jobs:
         with:
           ref: ${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && format('refs/tags/{0}', inputs.tag) || github.ref }}
           submodules: recursive
+          fetch-depth: 0
 
       - name: Resolve image metadata
         id: vars
@@ -69,8 +70,12 @@ jobs:
         run: |
           SHA="$(git rev-parse HEAD)"
           if [[ "$EVENT_NAME" == "workflow_call" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            # shellcheck source=scripts/release-config.sh
-            source scripts/release-config.sh
+            # A release branch's release-config.sh can predate functions this workflow
+            # (always run from main) expects, so pull main's copy rather than whatever
+            # is checked out at the tagged commit above.
+            git show origin/main:scripts/release-config.sh > "${RUNNER_TEMP}/release-config.sh"
+            # shellcheck source=/dev/null
+            source "${RUNNER_TEMP}/release-config.sh"
             if ! release_docker_image_version_from_tag "$INPUT_TAG" >/dev/null; then
               echo "::error::Invalid tag format: '$INPUT_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
               exit 1
@@ -180,6 +185,7 @@ jobs:
           sparse-checkout: |
             .github/actions
             scripts
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -202,12 +208,19 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          # shellcheck source=scripts/release-config.sh
-          source scripts/release-config.sh
+          # A release branch's release-config.sh can predate functions this workflow
+          # (always run from main) expects, so pull main's copy rather than whatever
+          # is checked out at the tagged commit above.
+          git show origin/main:scripts/release-config.sh > "${RUNNER_TEMP}/release-config.sh"
+          # shellcheck source=/dev/null
+          source "${RUNNER_TEMP}/release-config.sh"
           if ! IMAGE_VERSION="$(release_docker_image_version_from_tag "$RELEASE_TAG")"; then
             echo "::error::Invalid tag format: '$RELEASE_TAG' (expected e.g. v1.2.3 or v1.2.3-rc.1)"
             exit 1
           fi
+          # Defense in depth: never publish a vX.Y.Z-tagged image, even if the
+          # sourced parser regresses and stops stripping the leading "v".
+          IMAGE_VERSION="${IMAGE_VERSION#v}"
           SHA="$(git rev-parse HEAD)"
           SHORT_HASH="${SHA::8}"
           TAG="${IMAGE}:${IMAGE_VERSION}"


### PR DESCRIPTION
## Summary

`v0.7.3`'s public Docker images were tagged `v0.7.3` instead of `0.7.3`, inconsistent with every prior release.

## Details

Both the `build` and `manifest` jobs check out `refs/tags/{tag}` and then `source scripts/release-config.sh` from that same checked-out tree. The `v0.7.3` tag pointed at an older commit whose copy of `release-config.sh` predated the fix that strips the leading `v` from the parsed version — so `release_docker_image_version_from_tag` returned `v0.7.3` verbatim, and the `manifest` job tagged the image with it directly (`docker buildx imagetools create -t "${IMAGE}:${IMAGE_VERSION}"`).

Fix:
- Pull `scripts/release-config.sh` from `origin/main` instead of the tag checkout (needs `fetch-depth: 0` to make `origin/main` resolvable), so the parser used is always current regardless of which commit the tag happens to point at.
- Defense in depth: strip a stray leading `v` from `IMAGE_VERSION` right before building the tag, so a future parser regression can't silently republish a `vX.Y.Z` tag.

## Testing

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-docker.yaml')"` — clean
- `actionlint .github/workflows/build-docker.yaml` — clean
- Simulated the bug locally: an old `release-config.sh` (raw tag passthrough) checked out at a tag produces `v0.7.3`; sourcing the current `main` copy instead produces `0.7.3`.

## Documentation

N/A — CI workflow-only change.