### PR TITLE
chore(ci): pin every action reference to a published release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: rustfmt
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Install cargo-sort
         run: cargo install cargo-sort
@@ -59,7 +59,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: clippy
           cache-shared-key: rust-build
@@ -78,12 +78,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: rust-build
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
         with:
           tool: nextest
 
@@ -104,7 +104,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -120,12 +120,12 @@ jobs:
         run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: ${{ steps.foundry-version.outputs.version }}
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
         with:
           tool: nextest
 
@@ -185,7 +185,7 @@ jobs:
         run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: ${{ steps.foundry-version.outputs.version }}
 
@@ -215,7 +215,7 @@ jobs:
         run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: ${{ steps.foundry-version.outputs.version }}
 
@@ -237,7 +237,7 @@ jobs:
         run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: ${{ steps.foundry-version.outputs.version }}
 

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Validate runner target
         env:
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Install sccache
-        uses: taiki-e/install-action@a661f9d0b5f5222ce08202e6b2e9648d1713ca37 # untagged 2025-07-01 commit
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
         with:
           tool: sccache
 


### PR DESCRIPTION
## Summary

Every `uses:` reference in the repo now pins to a full-length commit SHA that resolves to a published release tag.

Two parts:

1. `ci.yml` was the only workflow with unpinned references. 11 `uses:` lines across 3 actions are now SHA-pinned.
2. `release-binaries.yaml` had two stale pins, refreshed here rather than deferred, per review feedback.

## ci.yml

11 `uses:` lines across 3 actions:

- `actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659` (v1.17.0)
- `foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a` (v1.9.0)
- `taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7` (v2.85.0)

## release-binaries.yaml

- `actions-rust-lang/setup-rust-toolchain`: v1.15.4 (`150fca88`) to v1.17.0 (`166cdcfd`), now byte-identical to the pin in `ci.yml`. This closes the gap where the release job installed its toolchain through a different action version than the one CI validated against.
- `taiki-e/install-action`: `a661f9d0` to v2.85.0 (`7572810d`). The old SHA carries no tag, is not an ancestor of the action's default branch, and dates to 2025-07-01, so the sccache install step was pinned to a point that could not be traced back to any release.

## Verification

- Every SHA was resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing annotated tags where present, then independently re-fetched with `gh api repos/<owner>/<repo>/commits/<sha>`, which echoed back the same SHA. Nothing was hand-written.
- `grep -E 'uses: .*@(v[0-9]|main|master)' .github/workflows/*.yml` returns no matches.
- Audited every remaining pin in `release-binaries.yaml`: `actions/checkout` v6.0.3, `actions/github-script` v9.0.0, `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1 and `crazy-max/ghaction-import-gpg` v7.0.0 all resolve cleanly to published tags. No other stale pin.
- `actionlint` on both files reports no new findings.

## Scope

`uses:` lines only, across two files. No indentation, ordering, or `with:` block changes.

Worth watching after merge: `install-action` moves roughly 13 months. The release job will not exercise it until the next tag build.