### PR TITLE
chore(ci): add least-privilege permissions to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   # Rust: fmt, deps, lint run in parallel -> unit tests after lint passes


### PR DESCRIPTION
## Summary

`ci.yml` is the only workflow in the repo without a top-level `permissions:` block, so its 10 jobs inherit the repository default token permissions. This adds `contents: read`, following the pattern `finalize-release.yaml` already uses: a restrictive top-level block, with jobs that need more declaring it themselves.

## Why this is safe

Every job was audited before the change:

- The only `GITHUB_TOKEN` reference in the file is inside the `proto` job, which already declares its own `permissions:` block (`contents: read` + `pull-requests: write`, matching what `bufbuild/buf-action` documents). A job-level block fully replaces the workflow-level one, so `proto` is unaffected.
- No other job runs `gh`, uses `actions/github-script`, posts comments, pushes commits, uploads release assets, or pushes images. `docker-build` runs with `push: false`.
- `Swatinem/rust-cache` (via `setup-rust-toolchain`) and BuildKit's `type=gha` cache both authenticate with `ACTIONS_RUNTIME_TOKEN`, which is not governed by `permissions:`.
- `taiki-e/install-action` passes `github.token` only to relieve cargo-binstall rate limiting, read-only.
- The three submodules are public third-party repos fetched over HTTPS.

## Scope

Two added lines, placed immediately before `jobs:` to mirror `finalize-release.yaml`. No job-level changes.