### PR TITLE
docs: use full release tags in Docker commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -201,11 +201,11 @@ Alternatively, build images from a release tag:
 
 ```sh
 git clone https://github.com/circlefin/arc-node.git && cd arc-node
-git checkout v$ARC_VERSION
+git checkout "$ARC_VERSION"
 docker buildx bake \
-  --set "*.args.GIT_COMMIT_HASH=$(git rev-parse v$ARC_VERSION^{commit})" \
-  --set "*.args.GIT_VERSION=v$ARC_VERSION" \
-  --set "*.args.GIT_SHORT_HASH=$(git rev-parse --short v$ARC_VERSION^{commit})" \
+  --set "*.args.GIT_COMMIT_HASH=$(git rev-parse "${ARC_VERSION}^{commit}")" \
+  --set "*.args.GIT_VERSION=$ARC_VERSION" \
+  --set "*.args.GIT_SHORT_HASH=$(git rev-parse --short "${ARC_VERSION}^{commit}")" \
   --set "arc-execution.tags=arc-execution:$ARC_VERSION" \
   --set "arc-consensus.tags=arc-consensus:$ARC_VERSION"
 ```

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -284,7 +284,7 @@ mkdir -p "${ARC_HOME:-$HOME/.arc}"
 Download `docker-compose.yml` into a working directory:
 
 ```sh
-curl -O https://raw.githubusercontent.com/circlefin/arc-node/v${ARC_VERSION}/deployments/docker-compose.yml
+curl -O https://raw.githubusercontent.com/circlefin/arc-node/${ARC_VERSION}/deployments/docker-compose.yml
 ```
 
 ### Start


### PR DESCRIPTION
## Summary

Use the full release tag stored in `ARC_VERSION` when checking out a release, deriving Docker build metadata, and downloading the Compose configuration.

The version table exposes full tags such as `v0.7.3`. The current commands prepend another `v`, producing references such as `vv0.7.3`, which do not exist.

This complements #199, which updates the version table and `arcup` example.

## Validation

- Confirmed `refs/tags/v0.7.3` exists; `vv0.7.3` does not.
- Confirmed the Compose URL for `v0.7.3` returns HTTP 200; the doubled-prefix URL returns HTTP 404.
- Shallow-cloned `v0.7.3` and verified the corrected checkout and revision expressions.
- Ran shell syntax validation and `git diff --check`.

No Docker image build or node bootstrap was run; those operations are not required to validate release-tag interpolation and would introduce unrelated compute and storage work.