### PR TITLE
fix: derive release kind from the tag, not a caller-supplied PR body field

### DIFF
--- a/.github/scripts/finalize-release.sh
+++ b/.github/scripts/finalize-release.sh
@@ -102,18 +102,6 @@ parse_release_metadata() {
 
   TAG="$(extract_body_field "Release tag")" || die "PR body is missing 'Release tag: ...'"
   RELEASE_BRANCH="$(extract_body_field "Release branch")" || die "PR body is missing 'Release branch: ...'"
-  RELEASE_KIND="$(extract_body_field "Release kind" || true)"
-  RELEASE_KIND="${RELEASE_KIND:-patch}"
-  # Trim leading/trailing whitespace and lowercase (field may be hand-edited in the PR body).
-  # Only outer whitespace is stripped, not internal, so a typo like "min or" still fails loudly.
-  RELEASE_KIND="${RELEASE_KIND#"${RELEASE_KIND%%[![:space:]]*}"}"
-  RELEASE_KIND="${RELEASE_KIND%"${RELEASE_KIND##*[![:space:]]}"}"
-  RELEASE_KIND="$(tr '[:upper:]' '[:lower:]' <<< "${RELEASE_KIND}")"
-
-  case "${RELEASE_KIND}" in
-    patch|minor|major) ;;
-    *) die "Invalid Release kind: ${RELEASE_KIND}" ;;
-  esac
 
   VERSION="$(tag_version)" || die "Release tags must start with ${TAG_PREFIX}: ${TAG}"
   [[ "${RELEASE_BRANCH}" == "${RELEASE_BRANCH_PREFIX}"* ]] || die "Release branches must start with ${RELEASE_BRANCH_PREFIX}: ${RELEASE_BRANCH}"
@@ -132,23 +120,23 @@ parse_release_metadata() {
   EXPECTED_RELEASE_BRANCH="${RELEASE_BRANCH_PREFIX}${MAJOR}.${MINOR}"
   [[ "${RELEASE_BRANCH}" == "${EXPECTED_RELEASE_BRANCH}" ]] || die "Release branch must be ${EXPECTED_RELEASE_BRANCH}, got ${RELEASE_BRANCH}"
 
-  EFFECTIVE_RELEASE_KIND="${RELEASE_KIND}"
-  if [[ "${RELEASE_KIND}" == "patch" && "${PATCH}" == "0" ]]; then
+  # Release kind is derived from the tag itself, not a caller-supplied PR body field: a label
+  # can drift out of sync with the tag it's supposed to describe (see the public-release-handoff
+  # fix on the private side, which hit this for a mismatched release_kind input).
+  if [[ "${PATCH}" != "0" ]]; then
+    EFFECTIVE_RELEASE_KIND="patch"
+  elif [[ "${MINOR}" == "0" ]]; then
+    EFFECTIVE_RELEASE_KIND="major"
+  else
     EFFECTIVE_RELEASE_KIND="minor"
-    note "Release kind promoted from patch to minor for ${TAG} (PATCH=0 means first release on a new branch)"
   fi
 
   case "${EFFECTIVE_RELEASE_KIND}" in
     patch)
       [[ "${PR_BASE_REF}" == "${RELEASE_BRANCH}" ]] || die "Patch release PRs must target ${RELEASE_BRANCH}, got ${PR_BASE_REF}"
       ;;
-    minor)
-      [[ "${PATCH}" == "0" ]] || die "Minor release PRs require an X.Y.0 tag, got ${TAG}"
-      [[ "${PR_BASE_REF}" == "${MAIN_BRANCH}" ]] || die "Minor release PRs must target ${MAIN_BRANCH}, got ${PR_BASE_REF}"
-      ;;
-    major)
-      [[ "${MINOR}" == "0" && "${PATCH}" == "0" ]] || die "Major release PRs require an X.0.0 tag, got ${TAG}"
-      [[ "${PR_BASE_REF}" == "${MAIN_BRANCH}" ]] || die "Major release PRs must target ${MAIN_BRANCH}, got ${PR_BASE_REF}"
+    minor|major)
+      [[ "${PR_BASE_REF}" == "${MAIN_BRANCH}" ]] || die "Minor/major release PRs must target ${MAIN_BRANCH}, got ${PR_BASE_REF}"
       ;;
   esac
 }
@@ -253,4 +241,6 @@ main() {
   write_outputs
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/scripts/test-finalize-release.sh
+++ b/.github/scripts/test-finalize-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/finalize-release.sh
+source "${SCRIPT_DIR}/finalize-release.sh"
+
+assert_eq() {
+  local expected="$1" actual="$2" message="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "FAIL: ${message}: expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_dies() {
+  local message="$1"
+  shift
+  if ( "$@" ) >/dev/null 2>&1; then
+    echo "FAIL: ${message}: expected failure, got success" >&2
+    exit 1
+  fi
+}
+
+sync_body() {
+  printf 'Automated final release sync.\n\nRelease tag: %s\nRelease branch: %s\n' "$1" "$2"
+}
+
+test_patch_release_kind_derived_from_tag() {
+  PR_BODY="$(sync_body v0.7.2 release/0.7)"
+  PR_BASE_REF="release/0.7"
+  PR_HEAD_REF="sync/v0_7_2"
+  parse_release_metadata
+  assert_eq "patch" "${EFFECTIVE_RELEASE_KIND}" "patch tag (no Release kind field) derives patch"
+}
+
+test_minor_release_kind_derived_from_tag() {
+  PR_BODY="$(sync_body v0.8.0 release/0.8)"
+  PR_BASE_REF="main"
+  PR_HEAD_REF="sync/v0_8_0"
+  parse_release_metadata
+  assert_eq "minor" "${EFFECTIVE_RELEASE_KIND}" "X.Y.0 tag (no Release kind field) derives minor"
+}
+
+test_major_release_kind_derived_from_tag() {
+  PR_BODY="$(sync_body v1.0.0 release/1.0)"
+  PR_BASE_REF="main"
+  PR_HEAD_REF="sync/v1_0_0"
+  parse_release_metadata
+  assert_eq "major" "${EFFECTIVE_RELEASE_KIND}" "X.0.0 tag (no Release kind field) derives major, not minor"
+}
+
+test_major_release_rejects_release_branch_base() {
+  PR_BODY="$(sync_body v1.0.0 release/1.0)"
+  PR_BASE_REF="release/1.0"
+  PR_HEAD_REF="sync/v1_0_0"
+  assert_dies "major release PR targeting its own release branch instead of main must fail" parse_release_metadata
+}
+
+test_patch_release_kind_derived_from_tag
+test_minor_release_kind_derived_from_tag
+test_major_release_kind_derived_from_tag
+test_major_release_rejects_release_branch_base
+
+echo "finalize-release tests passed"


### PR DESCRIPTION
## Summary
- `finalize-release.sh` read `Release kind` from the sync PR body, defaulting to `patch` when missing and only ever promoting `patch` -> `minor` when `PATCH==0`.
- Automated sync PRs no longer include a `Release kind` field in the body, so every release PR now silently classifies as `patch`/`minor`-by-promotion, misclassifying major (`X.0.0`) releases as `minor`.
- Derives `EFFECTIVE_RELEASE_KIND` purely from the tag's `MAJOR`/`MINOR`/`PATCH` fields instead of trusting a PR-body label at all.
- No functional impact today (branch/tag creation for `minor`/`major` was already identical code, and nothing currently consumes the `release_kind` output), but it was reporting the wrong value and would misfire silently if anything starts consuming that output (changelog generation, notifications, etc.).

## Changes
- `.github/scripts/finalize-release.sh`: remove `Release kind` PR-body parsing/validation; derive release kind from tag shape; guard `main "$@"` behind a `BASH_SOURCE` check so the parsing logic is sourceable for tests.
- `.github/scripts/test-finalize-release.sh` (new): covers patch/minor/major derivation from the tag alone (no `Release kind` field in the test PR bodies) and the base-branch validation for major releases.

## Test plan
- [x] `bash .github/scripts/test-finalize-release.sh` passes locally
- [x] `shellcheck .github/scripts/finalize-release.sh .github/scripts/test-finalize-release.sh` clean
- [ ] Public CI (`ci.yml`) on this PR