### PR TITLE
docs: update Arc Testnet version to v0.7.3 in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,7 @@ source "$ARC_HOME/env"
 To install a specific version, run `arcup` with `--install`:
 
 ```sh
-arcup --install v0.6.0
+arcup --install v0.7.3
 ```
 
 Next, verify that the three Arc binaries are installed:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ Consult the table below to confirm which version to run for each network.
 
 | Network     | Version |
 |-------------|---------|
-| Arc Testnet | v0.6.0  |
+| Arc Testnet | v0.7.3  |
 
 ## Pre-built Binary
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ Consult the table below to confirm which version to run for each network.
 
 | Network     | Version |
 |-------------|---------|
-| Arc Testnet | v0.7.3  |
+| Arc Testnet | v0.8.0  |
 
 ## Pre-built Binary
 
@@ -61,7 +61,7 @@ source "$ARC_HOME/env"
 To install a specific version, run `arcup` with `--install`:
 
 ```sh
-arcup --install v0.7.3
+arcup --install v0.8.0
 ```
 
 Next, verify that the three Arc binaries are installed:


### PR DESCRIPTION
## Summary

The Versions table in `docs/installation.md` listed `v0.6.0` as the required version for Arc Testnet. The current release is `v0.7.3`.

## Problem

A node operator following the installation guide would install `v0.6.0`, which can no longer sync with Arc Testnet. Per `BREAKING_CHANGES.md`:

> "testnet node operators must use v0.7.2 before timestamp 1781791200 (2026-06-18 14:00:00 UTC), when Zero7 activates on testnet. Earlier versions are not supported."

That deadline has passed — `v0.6.0` nodes are incompatible with the current testnet network.

## Change

- `docs/installation.md`: Versions table updated from `v0.6.0` → `v0.7.3`

Closes #225