### PR TITLE
chore(deps): bump malachite pin to current main — hardens no-peer sync branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-app"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-codec",
  "arc-malachitebft-config",
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-app-channel"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-app",
  "arc-malachitebft-config",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-codec"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "bytes",
 ]
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-config"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "bytesize",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-consensus"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-driver",
  "arc-malachitebft-core-types",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-driver"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-state-machine",
  "arc-malachitebft-core-types",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-state-machine"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "derive-where",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-types"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-peer",
  "async-trait",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-votekeeper"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "derive-where",
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-discovery"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-metrics",
  "either",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-engine"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-codec",
  "arc-malachitebft-config",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-metrics"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-state-machine",
  "prometheus-client",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-network"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-discovery",
  "arc-malachitebft-metrics",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-peer"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "bs58",
  "multihash",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-proto"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-signing"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "async-trait",
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-signing-ed25519"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "base64 0.22.1",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-sync"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "arc-malachitebft-core-types",
  "arc-malachitebft-metrics",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-wal"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite.git?rev=8ee5d998#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/circlefin/malachite.git?rev=5cd137fb#5cd137fb158fc52b55044eee9b090fd0d34996b0"
 dependencies = [
  "advisory-lock",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,67 +269,67 @@ wiremock = "0.6"
 [workspace.dependencies.malachitebft-app]
 package = "arc-malachitebft-app"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-app-channel]
 package = "arc-malachitebft-app-channel"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-codec]
 package = "arc-malachitebft-codec"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-config]
 package = "arc-malachitebft-config"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-core-consensus]
 package = "arc-malachitebft-core-consensus"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-core-state-machine]
 package = "arc-malachitebft-core-state-machine"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-core-types]
 package = "arc-malachitebft-core-types"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-network]
 package = "arc-malachitebft-network"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-peer]
 package = "arc-malachitebft-peer"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-proto]
 package = "arc-malachitebft-proto"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-signing]
 package = "arc-malachitebft-signing"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-signing-ed25519]
 package = "arc-malachitebft-signing-ed25519"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [workspace.dependencies.malachitebft-sync]
 package = "arc-malachitebft-sync"
 git = "https://github.com/circlefin/malachite.git"
-rev = "8ee5d998"
+rev = "5cd137fb"
 
 [profile.dev]
 # enable basic optimizations (otherwise reth can't process txs)


### PR DESCRIPTION
## Summary
Bumps the pinned `circlefin/malachite` git rev from `8ee5d998` (2026-05-22) to `5cd137fb` (current `main` tip). Pulls in circlefin/malachite#1567.

## Scope — please read before merging
This is a strict improvement and pulls in no unrelated commits, but **it does not close #214 on its own**. Per the trace in review comments below: #1567 only hardens the no-peer-available branch (`re_request_values_from_peer_except`'s rollback when no peer covers the failed range at all). The branch that actually causes the reported wedge — a peer *is* available but only covers a prefix of the failed range, and the untried suffix is silently dropped — is untouched by this bump. That fix (suffix-loop, drafted by @arjun215-eng, fork commit 378b0e5) has not yet landed in circlefin/malachite.

Contributes to #214, does not fix it. Recommend merging this as a standalone hardening change, then tracking the pin retarget to the suffix-loop fix as a separate follow-up once it lands upstream.

## Root cause of the (still-open) wedge
A batched sync fetch that partially fails advances `sync_height` past the entire failed range, but the peer-available retry path only re-requests the prefix the replacement peer can serve. The dropped suffix sits below `sync_height` with no covering pending request and is never re-issued.

## Testing
`Cargo.lock` regenerated against the new rev via `cargo build -p arc-node-consensus`.