### PR TITLE
fix(types): make the arbitrary feature self-contained

### DIFF
--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 
 [features]
 default = ["signer-local"]
-arbitrary = ["dep:arbitrary"]
+arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
 byzantine = ["dep:malachitebft-engine-byzantine"]
 signer-local = ["dep:malachitebft-signing-ed25519"]
 
@@ -23,7 +23,7 @@ alloy-rlp = { workspace = true }
 alloy-rpc-types-engine = { workspace = true, features = ["ssz"] }
 
 # others
-arbitrary = { workspace = true, optional = true }
+arbitrary = { workspace = true, optional = true, features = ["derive"] }
 arc-shared = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Fixes #233.

## Summary

The `arbitrary` feature of `arc-consensus-types` does not build on its own:

```console
$ cargo check -p arc-consensus-types --features arbitrary
error[E0433]: failed to resolve: could not find `Arbitrary` in `arbitrary`
  --> crates/types/src/address.rs:39:53
   |
39 | #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
   |                                                     ^^^^^^^^^ could not find `Arbitrary` in `arbitrary`
```

The feature gates `derive(arbitrary::Arbitrary)` on `Address`, but declares neither of the two things that derive needs:

1. **`arbitrary/derive`** — the derive macro itself lives behind that feature, hence the `E0433` above.
2. **`alloy-primitives/arbitrary`** — without it the generated impl fails with `the trait bound alloy_primitives::Address: Arbitrary<'_> is not satisfied`, since the wrapped type has no `Arbitrary` impl of its own.

## Why CI does not catch this

`arc-consensus-db` and `arc-node-consensus` both depend on `alloy-rpc-types-engine` with `features = ["arbitrary"]`. In a workspace build, feature unification turns on exactly what this crate omitted, so `--all-features` at the workspace level compiles and the gap stays hidden. It only surfaces when the crate is built alone — which is also how a consumer would build it, and `crates/types` inherits `publish` from the workspace rather than opting out.

## Change

Declare both, following the pattern `arc-evm` and `arc-node` already use, where the `arbitrary` feature forwards to the alloy dependencies explicitly:

```toml
arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
arbitrary = { workspace = true, optional = true, features = ["derive"] }
```

## Testing

- `cargo check -p arc-consensus-types --features arbitrary` — now compiles (this is the command that fails on `main`).
- `cargo check --workspace --all-features` — still passes, no regression.
- `cargo test -p arc-consensus-types --features arbitrary` — 192 tests pass.
- `cargo fmt --all --check` — clean.
- `Cargo.lock` is unchanged: `arbitrary`'s `derive` feature and `alloy-primitives/arbitrary` are both already enabled somewhere in the graph, so no version resolution moves.

I left the workspace-level `arbitrary = "1.3"` in the root `Cargo.toml` alone deliberately — adding `derive` there would enable it for every consumer of the workspace dependency, and only this crate needs it.
