### PR TITLE
chore(types): drop redundant macro imports that break CI on Rust 1.92

### DIFF
--- a/crates/types/src/codec/mod.rs
+++ b/crates/types/src/codec/mod.rs
@@ -77,8 +77,6 @@ macro_rules! impl_versioned_codec {
     };
 }
 
-pub(crate) use impl_versioned_codec;
-
 pub mod error;
 pub mod network;
 pub mod proto;

--- a/crates/types/src/codec/mod.rs
+++ b/crates/types/src/codec/mod.rs
@@ -26,6 +26,11 @@ pub use malachitebft_codec::{Codec, HasEncodedLen};
 /// - `$ty`: The message type to encode/decode
 /// - `$version_ty`: The version enum type
 /// - `$version_val`: The specific version value to use
+///
+/// Must stay above the `pub mod` declarations at the bottom of this file:
+/// `network` and `wal` reach this macro through textual scope, not through a
+/// path, so moving the module declarations above it — or moving this below
+/// them — breaks all 11 invocation sites with `cannot find macro`.
 macro_rules! impl_versioned_codec {
     ($codec_ty:ty, $ty:ty, $version_ty:ty, $version_val:expr) => {
         impl malachitebft_codec::Codec<$ty> for $codec_ty {

--- a/crates/types/src/codec/network.rs
+++ b/crates/types/src/codec/network.rs
@@ -23,7 +23,6 @@ use malachitebft_core_types::ValidatorProof;
 use malachitebft_sync::{self as sync};
 
 use crate::codec::error::CodecError;
-use crate::codec::impl_versioned_codec;
 use crate::codec::proto::ProtobufCodec;
 use crate::codec::versions::{
     LivenessMsgVersion, ProposalPartVersion, SignedConsensusMsgVersion, StreamMessageVersion,

--- a/crates/types/src/codec/wal.rs
+++ b/crates/types/src/codec/wal.rs
@@ -19,7 +19,6 @@
 use malachitebft_core_consensus::{ProposedValue, SignedConsensusMsg};
 use malachitebft_core_types::PolkaCertificate;
 
-use crate::codec::impl_versioned_codec;
 use crate::codec::versions::{
     PolkaCertificateVersion, ProposedValueVersion, SignedConsensusMsgVersion,
 };


### PR DESCRIPTION
Fixes #234.

## Summary

On Rust 1.92 the CI lint command fails on `arc-consensus-types`:

```console
$ cargo clippy --all-targets --all-features -- -D warnings
error: unused import: `crate::codec::impl_versioned_codec`
  --> crates/types/src/codec/network.rs:26:5
error: unused import: `crate::codec::impl_versioned_codec`
  --> crates/types/src/codec/wal.rs:22:5
error: could not compile `arc-consensus-types` (lib) due to 2 previous errors
```

`main` is green today only because `rust-toolchain.toml` pins `1.91.1`. Since the Rust Lint job runs with `-D warnings`, bumping the toolchain to 1.92 or later turns these into hard CI failures.

## Why the imports are redundant

`impl_versioned_codec` is a `macro_rules!` macro defined in `codec/mod.rs` above the `pub mod network;` and `pub mod wal;` declarations. Textual macro scoping already puts it in scope for both child modules, so `use crate::codec::impl_versioned_codec;` never resolved to anything the modules didn't already have. Rust 1.92 is simply the first release whose `unused_imports` lint reports it.

Removing the two imports leaves the `pub(crate) use impl_versioned_codec;` re-export in `codec/mod.rs` with no remaining users, and it warns in turn, so this drops that line as well. Nothing outside the `codec` module referenced the macro by path.

Net effect is 4 deleted lines and no behaviour change: textual macro scoping is long-stable and version-independent, so `impl_versioned_codec!` resolves identically on 1.91.1 and on 1.92.

## Testing

I do not have the pinned 1.91.1 toolchain available locally, so my verification ran on 1.92.0:

- `cargo clippy -p arc-consensus-types --all-targets -- -D warnings` — clean (fails on `main` with the two errors above).
- `cargo test -p arc-consensus-types` — 192 tests pass.
- `cargo fmt --all --check` — clean.

CI is the authority for the pinned toolchain, and this PR running against 1.91.1 is the check that matters — if the macro somehow did not resolve without the import, the build would fail outright rather than subtly. Happy to adjust if you would rather keep the imports and silence the lint another way (e.g. an `#[allow]`), though removing dead lines seemed preferable to carrying an allow for them.
