### PR TITLE
fix(types): make malachitebft-signing-ed25519 a required dependency

### DIFF
--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -8,10 +8,8 @@ rust-version.workspace = true
 publish.workspace = true
 
 [features]
-default = ["signer-local"]
 arbitrary = ["dep:arbitrary"]
 byzantine = ["dep:malachitebft-engine-byzantine"]
-signer-local = ["dep:malachitebft-signing-ed25519"]
 
 [dependencies]
 
@@ -43,7 +41,7 @@ malachitebft-core-types = { workspace = true, features = ["serde"] }
 malachitebft-engine-byzantine = { workspace = true, optional = true }
 malachitebft-proto = { workspace = true }
 malachitebft-signing = { workspace = true }
-malachitebft-signing-ed25519 = { workspace = true, optional = true, features = ["rand", "serde"] }
+malachitebft-signing-ed25519 = { workspace = true, features = ["rand", "serde"] }
 malachitebft-sync = { workspace = true }
 
 prost = { workspace = true }


### PR DESCRIPTION
Fixes #236.

## Summary

`arc-consensus-types` does not build with `--no-default-features`:

```console
$ cargo check -p arc-consensus-types --no-default-features
error[E0432]: unresolved import `malachitebft_signing_ed25519`
  --> crates/types/src/proposal_part.rs:26:5
  --> crates/types/src/codec/proto.rs:28:5
  --> crates/types/src/signing.rs:21:9
  --> crates/types/src/ssz/v1/vote.rs:21:5
```

The `signer-local` feature gated `dep:malachitebft-signing-ed25519`, but those four modules import it unconditionally and `feature = "signer-local"` never appears in a `#[cfg]` anywhere in the workspace. The feature offered no real choice — with it the crate builds, without it the build breaks on unresolved imports.


## The dependency was never really optional

`signing.rs` re-exports the dependency's types unconditionally:

```rust
pub use malachitebft_signing_ed25519::{Ed25519, PrivateKey, PublicKey, Signature};
```

So `Ed25519`, `PrivateKey`, `PublicKey` and `Signature` are part of this crate's public API regardless of the feature. A feature cannot meaningfully gate a dependency whose types the API surface hard-requires — the choice was never between an optional and a required dependency, only between declaring the truth and not. Raised by @osr21 on #236 and by @JspIIV on this PR, independently.

## Change


Make the dependency required, and drop `signer-local` together with the now-empty `default`. No crate in the workspace requested the feature explicitly, so nothing needs updating alongside this.

## Testing

- `cargo check -p arc-consensus-types --no-default-features` — now compiles (fails on `main`).
- `cargo check --workspace --all-features` — passes, no regression.
- `cargo test -p arc-consensus-types` — 192 tests pass.
- `cargo fmt --all --check` — clean.
- `Cargo.lock` unchanged.

## Two things worth your call

**Feature-name compatibility.** Removing the name means an external consumer spelling `features = ["signer-local"]` would hit an unknown-feature error — though no such consumer can exist today, since the crate does not build without it. If you would rather keep the spelling working, `signer-local = []` as a no-op alias gives the same fix; I am happy to switch. A third option is keeping the feature and adding a `compile_error!` guard the way `arc-signer` does, which turns the failure into a readable message but leaves a flag that can only ever be on.

**Overlap with #231.** That PR also edits the `[features]` table in `crates/types/Cargo.toml` (it declares the `arbitrary` feature's own dependencies, per #233). The two changes are independent and touch adjacent lines, so whichever lands second may need a trivial rebase — I will handle it, just let me know if you would prefer them combined into one PR instead.

