### PR TITLE
ci: wire up the arcup shell test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,19 @@ jobs:
           archive: false
 
   # ---------------------------------------------------------------------------
+  # arcup: shell test suite for the installer (no network, no toolchain, seconds to run)
+  # ---------------------------------------------------------------------------
+
+  arcup-test:
+    name: arcup Shell Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Run arcup test suite
+        run: bash arcup/test_arcup.sh
+
+  # ---------------------------------------------------------------------------
   # Solidity Contracts: lint (fast) -> build -> test
   # ---------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-it: up ## Run integration tests
 	cargo nextest run $(UNIT_TEST_ARGS) --features integration
 
 .PHONY: test-all
-test-all: test-it test-unit-contract ## Run all tests
+test-all: test-it test-unit-contract test-arcup ## Run all tests
 	@echo running all tests...
 	make smoke LAUNCH_ARGS="--frozen --healthy-retry=130"
 
@@ -158,6 +158,11 @@ cov-report: cov-unit ## Generate the coverage report
 .PHONY: cov-show
 cov-show: cov-report ## Generate coverage report and open in browser
 	open target/llvm-cov/html/index.html
+
+.PHONY: test-arcup
+test-arcup: ## Run the arcup installer shell test suite
+	@echo running arcup shell tests...
+	bash arcup/test_arcup.sh
 
 .PHONY: test-unit-contract
 test-unit-contract: check-foundry ## Run contract unit tests with coverage


### PR DESCRIPTION
## Summary
`arcup/test_arcup.sh` (829 lines, 24 assertions) currently passes but is never invoked anywhere -- not by CI, not by the Makefile, not by any other script. It already covers exactly the surface area where arcup's externally reported defects have concentrated (#204, #205): version comparison, checksum verification, archive extraction safety (symlink/path-traversal rejection), and download fallback behavior.

## What this does *not* claim
The suite passes on `main` today and does not currently have assertions that catch #204 or #205 -- those need new test cases in a follow-up, per the issue. This PR only makes the existing suite reachable.

## Changes
- `Makefile`: new `test-arcup` target (also added to `test-all`)
- `.github/workflows/ci.yml`: new `arcup-test` job -- no Rust toolchain or network needed, just checkout + `bash arcup/test_arcup.sh`, styled after the lightweight `proto` job

## Testing
```
$ make test-arcup
... 24/24 ok
```

Note: `test-finalize-release.sh`, the other suite named in #248, is already covered by #249 -- this PR only handles the `arcup` half.

Fixes #248