### PR TITLE
Docs/update arc testnet version and docker compose placeholders

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -5,8 +5,8 @@
 # Logs:   docker compose logs -f
 #
 # Required environment variables (see docs/running-an-arc-node.md#docker):
-#   ARC_EXECUTION_IMAGE  — EL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-execution:0.6.0)
-#   ARC_CONSENSUS_IMAGE  — CL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-consensus:0.6.0)
+#   ARC_EXECUTION_IMAGE  — EL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-execution:${ARC_VERSION})
+#   ARC_CONSENSUS_IMAGE  — CL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-consensus:${ARC_VERSION})
 #   ARC_HOME             — data directory on the host (e.g. ~/.arc)
 
 services:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ Consult the table below to confirm which version to run for each network.
 
 | Network     | Version |
 |-------------|---------|
-| Arc Testnet | v0.6.0  |
+| Arc Testnet | v0.7.3  |
 
 ## Pre-built Binary
 


### PR DESCRIPTION
## Summary
Fixes #238 and #225.

1. Updates `docs/installation.md` Versions table to list active Arc Testnet version `v0.7.3` (previously `v0.6.0`), aligned with official GitHub API release data.
2. Replaces hardcoded `0.6.0` image tags in `deployments/docker-compose.yml` header comments with the `${ARC_VERSION}` variable placeholder to align with `docs/running-an-arc-node.md`.

## Rationale
Ensures node operators downloading pre-built binaries or Docker Compose specs target the correct current Arc Testnet release.