### PR TITLE
docs: mainnet operator notes — versions table row and network selection guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,13 @@ Consult the table below to confirm which version to run for each network.
 | Network     | Version |
 |-------------|---------|
 | Arc Testnet | v0.6.0  |
+| Arc Mainnet | v0.7.0 or later |
+
+> **Mainnet version floor:** mainnet node operators must run **v0.7.0 or
+> later** — earlier versions are not supported. From v0.7.0 the consensus
+> layer advertises Arc-branded libp2p protocol identifiers on mainnet
+> (chain ID `5042`), so a pre-v0.7.0 CL cannot peer with the mainnet mesh.
+> See [BREAKING_CHANGES.md](../BREAKING_CHANGES.md#v070) for details.
 
 ## Pre-built Binary
 

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -17,6 +17,39 @@ You can run a node using [binaries](#binaries) or [Docker](#docker).
 Refer to the [installation](installation.md) instructions to obtain the
 binaries or Docker images.
 
+## Choosing a network
+
+Arc runs multiple networks. The examples in this guide target **Arc Testnet**;
+to run a node on another network, substitute the `--chain` value and chain ID
+accordingly:
+
+| Network     | `--chain` value | Chain ID  | Minimum node version |
+|-------------|-----------------|-----------|----------------------|
+| Arc Testnet | `arc-testnet`   | `5042002` | see [installation](installation.md#versions) |
+| Arc Mainnet | `arc-mainnet`   | `5042`    | `v0.7.0` |
+
+Both chainspecs are bundled in the node binaries — `--chain arc-mainnet`
+adopts the mainnet genesis configuration exactly as `--chain arc-testnet`
+does for testnet, with no external genesis file required.
+
+**Mainnet-specific notes:**
+
+- **Version floor.** Mainnet operators must run **v0.7.0 or later**; earlier
+  versions are not supported. From v0.7.0, the consensus layer advertises
+  Arc-branded libp2p protocol identifiers on mainnet, so a pre-v0.7.0 CL
+  cannot peer with v0.7.0+ nodes. Do not stage rollouts across the v0.7.0
+  boundary — a subset of nodes left on `v0.6.x` fragments the mainnet mesh.
+  See [BREAKING_CHANGES.md](../BREAKING_CHANGES.md#v070).
+- **Snapshots.** Syncing from genesis is not supported on any Arc network, so
+  bootstrapping a mainnet node requires a mainnet snapshot
+  (`arc-snapshots download --chain=arc-mainnet ...`), available once published
+  to the snapshot service.
+- **RPC endpoints.** The `--rpc.forwarder` and `--follow.endpoint` URLs shown
+  in this guide are testnet endpoints. For mainnet, substitute the mainnet
+  RPC endpoints published by your RPC providers; do not point a mainnet node
+  at testnet endpoints (the chain IDs differ and the node will reject the
+  data).
+
 ## Binaries
 
 ### Configure paths


### PR DESCRIPTION
## Summary

With Arc mainnet approaching, the operator docs only describe testnet. This PR adds the mainnet facts that are already verifiable from this repository — nothing speculative, no invented endpoints.

**`docs/installation.md`** — adds an **Arc Mainnet** row (`v0.7.0 or later`) to the Versions table, with a note carrying the version floor and the v0.7.0 libp2p peering implication over from BREAKING_CHANGES.md, where operators reading the installation page currently won't see it.

**`docs/running-an-arc-node.md`** — adds a **"Choosing a network"** section after the intro:
- testnet/mainnet table: `--chain` value, chain ID, minimum version
- both chainspecs are bundled in the binaries (`arc-mainnet` is a named chainspec since v0.7.0 — `crates/execution-config/src/chainspec.rs` registers it, genesis at `assets/mainnet/genesis.json`)
- mainnet notes: v0.7.0 floor + no staged rollouts across the boundary (per BREAKING_CHANGES), snapshot bootstrap via `--chain=arc-mainnet` once mainnet snapshots are published, and a warning not to reuse the guide's testnet RPC/follow endpoints on mainnet

## What this PR deliberately does NOT do

- **Does not touch the existing testnet row** (`v0.6.0` → `v0.7.3` is #226's claimed fix; this PR only adds adjacent lines, though whichever merges second will need a trivial rebase of that hunk).
- **Does not list mainnet RPC or snapshot URLs** — none are publicly resolvable yet (I checked; `snapshots.arc.network` has no `arc-mainnet` manifest and no mainnet RPC hostname answers). The text says "once published" rather than inventing endpoints. Happy to follow up with concrete URLs when Circle publishes the mainnet infrastructure.

## Verification

- Chain ID `5042` and the `arc-mainnet` chainspec name verified against `crates/shared/src/chain_ids.rs` and `crates/execution-config/src/chainspec.rs` on main.
- Version floor and peering rules verified against `BREAKING_CHANGES.md` / `CHANGELOG.md` v0.7.0 entries.
- Both files render cleanly; links checked relative to the docs directory.