### PR TITLE
docs: document official chain IDs and canonical testnet explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ To connect a wallet to Arc Testnet:
 > ```
 
 > [!NOTE]
-> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app** and
-> documentation lives at **https://docs.arc.network**. Older explorer URLs such as
-> `explorer.testnet.arc.network`, `explorer.arc.io`, and `docs.arc.io` are dead
-> (unreachable, login-gated, or 404) — do not use them in wallet `blockExplorerUrls`
-> configs or transaction links.
+> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app**. Other
+> explorer URLs that circulate in older guides — `explorer.testnet.arc.network`
+> (unreachable) and `explorer.arc.io` (team-login-gated) — are not publicly usable;
+> don't put them in wallet `blockExplorerUrls` configs or transaction links.
 
 ## Install and Run a Node
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ To connect a wallet to Arc Testnet:
 > # {"result":"0x4cef52"}  =  5042002
 > ```
 
+> [!NOTE]
+> The canonical Arc Testnet block explorer is **https://testnet.arcscan.app** and
+> documentation lives at **https://docs.arc.network**. Older explorer URLs such as
+> `explorer.testnet.arc.network`, `explorer.arc.io`, and `docs.arc.io` are dead
+> (unreachable, login-gated, or 404) — do not use them in wallet `blockExplorerUrls`
+> configs or transaction links.
+
 ## Install and Run a Node
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ To connect a wallet to Arc Testnet:
 | Block explorer  | https://testnet.arcscan.app     |
 
 > [!IMPORTANT]
-> Arc Testnet's chain ID is **`5042002`** (`0x4cef52`). Some third-party chain
-> registries and older community guides incorrectly list `1516` — that value is
-> **wrong** and will cause wallet connection failures. You can verify the chain
-> ID returned by a node directly:
+> Arc Testnet's chain ID is **`5042002`** (`0x4cef52`). The canonical registry
+> (chainid.network) already lists this correctly. Wrong values circulate in
+> community guides that confuse this chain with similarly named ones: `1516`
+> belongs to Story Odyssey Testnet, and `1243`/`1244` belong to a deprecated,
+> unrelated project also called ARC. Any of these will cause wallet connection
+> failures. You can verify the chain ID returned by a node directly:
 >
 > ```bash
 > curl -X POST https://rpc.testnet.arc.network \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,39 @@ Arc is an open EVM-compatible layer 1 built on [Malachite](https://github.com/ci
 - 🗳️ **[Consensus](crates/malachite-app/README.md)** - Consensus binary and configuration
 - More: see Arc [developer docs](https://docs.arc.io/arc/concepts/welcome-to-arc) for guides, APIs, and specs
 
+## Networks
+
+Arc's official chain IDs:
+
+| Network | Chain ID  | Hex        |
+| ------- | --------- | ---------- |
+| Mainnet | `5042`    | `0x13b2`   |
+| Testnet | `5042002` | `0x4cef52` |
+| Devnet  | `5042001` | `0x4cef51` |
+
+To connect a wallet to Arc Testnet:
+
+| Parameter       | Value                           |
+| --------------- | ------------------------------- |
+| Network name    | Arc Testnet                     |
+| Chain ID        | `5042002` (`0x4cef52`)          |
+| RPC URL         | https://rpc.testnet.arc.network |
+| Currency symbol | USDC                            |
+| Block explorer  | https://testnet.arcscan.app     |
+
+> [!IMPORTANT]
+> Arc Testnet's chain ID is **`5042002`** (`0x4cef52`). Some third-party chain
+> registries and older community guides incorrectly list `1516` — that value is
+> **wrong** and will cause wallet connection failures. You can verify the chain
+> ID returned by a node directly:
+>
+> ```bash
+> curl -X POST https://rpc.testnet.arc.network \
+>   -H "Content-Type: application/json" \
+>   -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+> # {"result":"0x4cef52"}  =  5042002
+> ```
+
 ## Install and Run a Node
 
 ### Install


### PR DESCRIPTION
Adds a "Networks" section to the README with Arc's official chain IDs and a
wallet connection table for Testnet.

Two corrections this fixes:

1. Chain ID. Arc Testnet is `5042002` (`0x4cef52`). Several third-party chain
   registries and community guides list `1516`, which causes wallet connection
   failures. The section includes an `eth_chainId` curl call so readers can
   verify against a live node.

2. Explorer URL. The canonical testnet explorer is https://testnet.arcscan.app.
   Older guides point at `explorer.testnet.arc.network` (unreachable) and
   `explorer.arc.io` (login-gated), neither of which is publicly usable.

README only, no code changes.

Split out of #195 so the security fix there can be reviewed on its own.