### PR TITLE
docs: clarify RPC behavior and validate rustdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
         with:
           components: rustfmt
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
 
       - name: Build workspace documentation
         env:
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
 
       - name: Install cargo-sort
         run: cargo install cargo-sort
@@ -73,7 +73,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
         with:
           components: clippy
           cache-shared-key: rust-build
@@ -92,7 +92,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
         with:
           cache-shared-key: rust-build
 
@@ -118,7 +118,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libclang-dev zlib1g-dev
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@0267444136ce4919088f5eae0461f736f21356de # v1
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
+  rust-doc:
+    name: Rust Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build workspace documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps --all-features --locked
+
   rust-deps:
     name: Rust Dependencies
     runs-on: ubuntu-latest

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -7,6 +7,7 @@ Each bullet is prefixed with a flag identifying the kind of breaking change:
 - `[CLI]` -- CLI flag added, renamed, removed, or made required.
 - `[Config]` -- default value, environment variable, or manifest field change.
 - `[Format]` -- log, metric label, or serialized output format change that breaks parsers.
+- `[RPC]` -- externally observable JSON-RPC behavior change that can affect applications.
 
 Entries are split by audience. A change appears under `### For Validators` when validator-mode operation must change; otherwise it appears under `### For Node Operators`. A change requiring both audiences to act appears in both sections (rare).
 
@@ -26,9 +27,10 @@ No breaking changes in this release.
 
 ### For Node Operators
 
-- **[Config] `arc-node-execution`: JSON-RPC gas cap default lowered.**
+- **[Config][RPC] `arc-node-execution`: JSON-RPC gas cap default lowered.**
   - Old (`v0.7.1`): `--rpc.gascap` default `50000000` (Reth stock default).
   - New (`v0.7.2`): `--rpc.gascap` default `30000000`.
+  - The RPC gas cap limits gas available to `eth_call` and `eth_estimateGas` simulations. It is an RPC execution limit, not the protocol maximum gas limit for an on-chain transaction.
   - `eth_call` and `eth_estimateGas` requests that need more than 30M gas now fail with a gas-cap error. Pass `--rpc.gascap 50000000` (or higher) to restore the previous budget. Operators who never set the flag and do not rely on calls above 30M gas are unaffected.
 
 - **[CLI] `arc-node-execution`: replay-unprotected (pre-EIP-155) transactions are rejected over JSON-RPC by default.**

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -33,12 +33,12 @@ No breaking changes in this release.
   - The RPC gas cap limits gas available to `eth_call` and `eth_estimateGas` simulations. It is an RPC execution limit, not the protocol maximum gas limit for an on-chain transaction.
   - `eth_call` and `eth_estimateGas` requests that need more than 30M gas now fail with a gas-cap error. Pass `--rpc.gascap 50000000` (or higher) to restore the previous budget. Operators who never set the flag and do not rely on calls above 30M gas are unaffected.
 
-- **[CLI] `arc-node-execution`: replay-unprotected (pre-EIP-155) transactions are rejected over JSON-RPC by default.**
+- **[CLI][RPC] `arc-node-execution`: replay-unprotected (pre-EIP-155) transactions are rejected over JSON-RPC by default.**
   - Old (`v0.7.1`): pre-EIP-155 (replay-unprotected) transactions were accepted over JSON-RPC.
   - New (`v0.7.2`): they are rejected by default with "only replay-protected (EIP-155) transactions allowed over RPC".
   - Adds `--arc.rpc.allow-unprotected-txs` (default `false`); set it to accept legacy unprotected transactions over RPC.
 
-- **[Config] `arc-node-execution`: JSON-RPC batch requests are capped.**
+- **[Config][RPC] `arc-node-execution`: JSON-RPC batch requests are capped.**
   - Old (`v0.7.1`): no limit on the number of entries in a JSON-RPC batch request.
   - New (`v0.7.2`): `--arc.rpc.max-batch-entries` defaults to `100`; oversized batches are rejected with JSON-RPC error `-32600` before any per-entry handler runs. A value of `0` is rejected so the cap cannot be silently disabled.
   - Operators whose tooling submits larger batches must raise `--arc.rpc.max-batch-entries <COUNT>`.
@@ -56,7 +56,7 @@ No breaking changes in this release.
 
 ### For Node Operators
 
-- **[Config] `arc-node-execution`: EL RPC connection defaults tightened.**
+- **[Config][RPC] `arc-node-execution`: EL RPC connection defaults tightened.**
   - `--rpc.max-connections` default: `500` -> `250`.
   - `--rpc.max-subscriptions-per-connection` default: `1024` -> `32`.
   - Both flags remain accepted on `arc-node-execution`; operators that need the previous behavior must pass them explicitly. The new defaults bound a WebSocket subscription fan-out memory pressure path; real-world clients typically multiplex around five subscriptions per socket and are unaffected.

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -5,8 +5,8 @@
 # Logs:   docker compose logs -f
 #
 # Required environment variables (see docs/running-an-arc-node.md#docker):
-#   ARC_EXECUTION_IMAGE  — EL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-execution:0.6.0)
-#   ARC_CONSENSUS_IMAGE  — CL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-consensus:0.6.0)
+#   ARC_EXECUTION_IMAGE  — EL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-execution:0.7.3)
+#   ARC_CONSENSUS_IMAGE  — CL Docker image (e.g. docker.cloudsmith.io/circle/arc-network/arc-consensus:0.7.3)
 #   ARC_HOME             — data directory on the host (e.g. ~/.arc)
 
 services:

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -219,7 +219,7 @@ curl -s -X POST http://localhost:8545 \
 
 The produced output is in JSON format.
 The `result` field represents the latest block number known to the node, in hexadecimal.
-It is not the next block height. You can use `printf "%0d"` to translate it into decimal.
+It is not the next block height. You can use `printf "%d\n" 0x64` to translate a hexadecimal value into decimal.
 It should increase over time.
 If it remains `0x0`, check the logs of the consensus layer for errors.
 Common causes are a missing or incomplete snapshot, mismatched `$ARC_RUN`

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -218,8 +218,8 @@ curl -s -X POST http://localhost:8545 \
 ```
 
 The produced output is in JSON format.
-The `result` field represents the next block height, in hexadecimal
-(you can use `printf "%0d"` to translate it into decimal).
+The `result` field represents the latest block number known to the node, in hexadecimal.
+It is not the next block height. You can use `printf "%0d"` to translate it into decimal.
 It should increase over time.
 If it remains `0x0`, check the logs of the consensus layer for errors.
 Common causes are a missing or incomplete snapshot, mismatched `$ARC_RUN`

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -218,8 +218,8 @@ curl -s -X POST http://localhost:8545 \
 ```
 
 The produced output is in JSON format.
-The `result` field represents the latest block number known to the node, in hexadecimal.
-It is not the next block height. You can use `printf "%d\n" 0x64` to translate a hexadecimal value into decimal.
+The `result` field represents the next block height, in hexadecimal
+(you can use `printf "%0d"` to translate it into decimal).
 It should increase over time.
 If it remains `0x0`, check the logs of the consensus layer for errors.
 Common causes are a missing or incomplete snapshot, mismatched `$ARC_RUN`


### PR DESCRIPTION
Closes #271
Closes #270
Closes #257
Closes #235 

## Summary

This pull request groups four focused documentation and CI improvements:

- Explain that the JSON-RPC gas cap limits `eth_call` and `eth_estimateGas` simulations and is distinct from the protocol transaction gas limit.
- - Add an `[RPC]` breaking-change category for application-facing JSON-RPC behavior changes.
- - Update Docker Compose image examples from v0.6.0 to v0.7.3.
- - Add a CI job that runs workspace rustdoc with warnings treated as errors.
The separate `eth_blockNumber` clarification is tracked in #272 and is implemented by PR #274.

## Validation

`git diff --check` passed. Rust formatting and rustdoc execution were unavailable locally because Cargo is not installed in the sandbox.
