### PR TITLE
docs(types): record that the codec macros must precede the mod declarations

### DIFF
--- a/crates/types/src/codec/mod.rs
+++ b/crates/types/src/codec/mod.rs
@@ -26,6 +26,11 @@ pub use malachitebft_codec::{Codec, HasEncodedLen};
 /// - `$ty`: The message type to encode/decode
 /// - `$version_ty`: The version enum type
 /// - `$version_val`: The specific version value to use
+///
+/// Must stay above the `pub mod` declarations at the bottom of this file:
+/// `network` reaches this macro through textual scope, not through a path, so
+/// moving the module declarations above it — or moving this below them —
+/// breaks all 8 invocation sites with `cannot find macro`.
 macro_rules! impl_versioned_codec {
     ($codec_ty:ty, $ty:ty, $version_ty:ty, $version_val:expr) => {
         impl malachitebft_codec::Codec<$ty> for $codec_ty {
@@ -75,6 +80,9 @@ macro_rules! impl_versioned_codec {
 /// This is only for persisted data formats that predate version bytes, such as
 /// the WAL. Networked types are already versioned and should use
 /// `impl_versioned_codec!` instead.
+///
+/// Same ordering constraint as `impl_versioned_codec!`: `wal` reaches this
+/// through textual scope, so it must stay above the `pub mod` declarations.
 macro_rules! impl_versioned_codec_with_legacy_fallback {
     ($codec_ty:ty, $ty:ty, $version_ty:ty, $version_val:expr) => {
         impl malachitebft_codec::Codec<$ty> for $codec_ty {


### PR DESCRIPTION
`network` and `wal` reach `impl_versioned_codec!` and `impl_versioned_codec_with_legacy_fallback!` through textual scope — there is no path import and no `pub(crate) use` re-export on `main`. Hoisting the `pub mod` block above the macros, or alphabetising `codec/mod.rs`, breaks all 11 invocation sites with `cannot find macro`, and nothing at those sites hints at the dependency.

Two comment lines, one per macro, so moving either one alone still surfaces the constraint. No behaviour change; `cargo check -p arc-consensus-types` and `cargo fmt --all --check` clean.

Context: @osr21 raised this while reviewing #232, which proposed removing the imports that made the ordering irrelevant. The v0.8.0 sync (#285) removed them upstream instead, so #232 is superseded — but the fragility it would have introduced now exists on `main` undocumented, and with a second macro depending on it. Closing #232 in favour of this.