### PR TITLE
fix(arcup): check disk space in TMP_DIR, not just BIN_DIR

### DIFF
--- a/arcup/arcup
+++ b/arcup/arcup
@@ -750,7 +750,14 @@ main() {
 
     mkdir -p "$BIN_DIR"
 
+    # The archive is downloaded into TMP_DIR and also extracted there before
+    # the binaries are copied to BIN_DIR, so TMP_DIR briefly holds both the
+    # compressed archive and its extracted contents (~2x the final install
+    # size). TMP_DIR (from mktemp -d, usually /tmp) is frequently a
+    # different filesystem than BIN_DIR — e.g. a small tmpfs in containers —
+    # so it needs its own check rather than relying on the BIN_DIR check.
     check_disk_space "$BIN_DIR"
+    check_disk_space "$TMP_DIR" 1000
 
     PLATFORM=$(detect_platform)
     ARCH=$(detect_arch)

--- a/arcup/arcup
+++ b/arcup/arcup
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-ARCUP_INSTALLER_VERSION="0.2.0"
+ARCUP_INSTALLER_VERSION="0.2.1"
 
 REPO="${ARC_REPO:-circlefin/arc-node}"
 if [[ -n "${ARC_REPO:-}" ]] && [[ ! "$ARC_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
@@ -752,12 +752,15 @@ main() {
 
     # The archive is downloaded into TMP_DIR and also extracted there before
     # the binaries are copied to BIN_DIR, so TMP_DIR briefly holds both the
-    # compressed archive and its extracted contents (~2x the final install
-    # size). TMP_DIR (from mktemp -d, usually /tmp) is frequently a
-    # different filesystem than BIN_DIR — e.g. a small tmpfs in containers —
-    # so it needs its own check rather than relying on the BIN_DIR check.
+    # compressed archive and its extracted contents. TMP_DIR (from
+    # mktemp -d, usually /tmp) is frequently a different filesystem than
+    # BIN_DIR — e.g. a small tmpfs in containers — so it needs its own
+    # check rather than relying on the BIN_DIR check. The measured v0.8.0
+    # x86_64-unknown-linux-gnu release peaks around 185MB in TMP_DIR
+    # (~52MB archive + ~133MB extracted); 300MB keeps headroom for growth
+    # without over-requiring on small-tmpfs hosts that install fine today.
     check_disk_space "$BIN_DIR"
-    check_disk_space "$TMP_DIR" 1000
+    check_disk_space "$TMP_DIR" 300
 
     PLATFORM=$(detect_platform)
     ARCH=$(detect_arch)

--- a/arcup/test_arcup.sh
+++ b/arcup/test_arcup.sh
@@ -810,6 +810,67 @@ test_install_binary_rejects_symlink() {
     pass "install_binary rejects symlink"
 }
 
+test_check_disk_space_rejects_insufficient() {
+    if ( check_disk_space "$TEST_TMP" 999999999 ) >"$TEST_TMP/disk-space.out" 2>&1; then
+        cat "$TEST_TMP/disk-space.out" >&2
+        fail "check_disk_space rejects insufficient space"
+    fi
+
+    grep -q "Insufficient disk space" "$TEST_TMP/disk-space.out" || {
+        cat "$TEST_TMP/disk-space.out" >&2
+        fail "check_disk_space rejects insufficient space"
+    }
+    pass "check_disk_space rejects insufficient space"
+}
+
+# Regression test for: check_disk_space was only ever called on BIN_DIR,
+# even though the archive is downloaded and extracted into TMP_DIR first
+# (mktemp -d, usually a different filesystem than BIN_DIR, e.g. a small
+# tmpfs in containers). A full disk there produced a raw curl/tar failure
+# instead of the friendly "Insufficient disk space" error. This drives
+# TMP_DIR (via TMPDIR) onto a fake-df'd path with plenty of space for
+# BIN_DIR but almost none for TMP_DIR, and asserts main() catches it.
+test_main_checks_tmp_dir_disk_space() {
+    local install_dir="$TEST_TMP/disk-space-install"
+    local scratch_dir="$TEST_TMP/disk-space-scratch"
+    mkdir -p "$install_dir" "$scratch_dir"
+
+    local fakebin="$TEST_TMP/disk-space-fakebin"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/df" <<EOF
+#!/usr/bin/env bash
+dir="\${*: -1}"
+case "\$dir" in
+    "$scratch_dir"*)
+        echo "Filesystem 1K-blocks Used Available Use% Mounted on"
+        echo "tmpfs 102400 0 1024 1% \$dir"
+        ;;
+    *)
+        echo "Filesystem 1K-blocks Used Available Use% Mounted on"
+        echo "/dev/sda1 999999999 0 999999999 1% \$dir"
+        ;;
+esac
+EOF
+    chmod 755 "$fakebin/df"
+
+    if \
+        TMPDIR="$scratch_dir" \
+        PATH="$fakebin:$PATH" \
+        ARC_BIN_DIR="$install_dir" \
+        ARC_REPO="test/arc-node" \
+        "$ROOT_DIR/arcup/arcup" -i "1.2.3" \
+        >"$TEST_TMP/disk-space-main.out" 2>&1; then
+        cat "$TEST_TMP/disk-space-main.out" >&2
+        fail "main rejects insufficient TMP_DIR disk space"
+    fi
+
+    grep -q "Insufficient disk space" "$TEST_TMP/disk-space-main.out" || {
+        cat "$TEST_TMP/disk-space-main.out" >&2
+        fail "main rejects insufficient TMP_DIR disk space"
+    }
+    pass "main rejects insufficient TMP_DIR disk space"
+}
+
 test_version_normalization
 test_version_comparison
 test_target_mapping
@@ -827,3 +888,5 @@ test_fixture_install_matrix
 test_archive_path_traversal_fails
 test_archive_link_entries_fail
 test_install_binary_rejects_symlink
+test_check_disk_space_rejects_insufficient
+test_main_checks_tmp_dir_disk_space


### PR DESCRIPTION
## Summary

`main()` in `arcup/arcup` calls `check_disk_space` exactly once, on `BIN_DIR`:

```sh
mkdir -p "$BIN_DIR"
check_disk_space "$BIN_DIR"
```

But the release archive is downloaded into `TMP_DIR` (`mktemp -d`, usually
`/tmp`) and also **extracted there** before the binaries are copied to
`BIN_DIR`. So `TMP_DIR` briefly needs to hold both the compressed archive
and its extracted contents (~2x the final install size), and it is never
checked at all.

`TMP_DIR` and `BIN_DIR` are frequently different filesystems — e.g. `/tmp`
is a small tmpfs in many containers/CI images while `BIN_DIR`
(`$ARC_DIR/bin`, under `$HOME`) sits on a much larger disk. In that case the
`BIN_DIR` check passes even though there isn't enough room in `TMP_DIR`, and
the user gets an opaque `curl`/`tar` failure instead of the intended
friendly `Insufficient disk space` error.

## Fix

Add a `check_disk_space` call for `TMP_DIR` as well, with a higher
threshold (1000MB vs. the 500MB default) since it temporarily holds both
the archive and its extracted contents.

```sh
check_disk_space "$BIN_DIR"
check_disk_space "$TMP_DIR" 1000
```

## Testing

- Added `test_check_disk_space_rejects_insufficient`: direct unit test that
  `check_disk_space` errors with `Insufficient disk space` when the
  required size exceeds what's available.
- Added `test_main_checks_tmp_dir_disk_space`: end-to-end regression test.
  Points `TMPDIR` at a directory whose fake `df` output reports ~1MB free
  while `BIN_DIR` reports effectively unlimited space, runs the real
  `arcup` binary via `arcup -i 1.2.3`, and asserts it fails with the
  `Insufficient disk space` message (proving the failure comes from the new
  `TMP_DIR` check and not the pre-existing `BIN_DIR` check).
- Ran the full suite locally: all 27 assertions pass (25 pre-existing + 2
  new).

```
$ bash arcup/test_arcup.sh
...
ok - install_binary rejects symlink
ok - check_disk_space rejects insufficient space
ok - main rejects insufficient TMP_DIR disk space
```

No functional changes outside `arcup/arcup` and `arcup/test_arcup.sh`.