### PR TITLE
fix: monitoring.md permissions note and arcup checksum filename validation

### DIFF
--- a/arcup/arcup
+++ b/arcup/arcup
@@ -654,11 +654,13 @@ verify_checksum_file() {
     local archive_path="$1"
     local checksum_path="$2"
     local archive_name="$3"
-    local expected_checksum expected_name actual_checksum
+    local expected_checksum expected_name actual_checksum line
 
-    if ! read -r expected_checksum expected_name < "$checksum_path"; then
+    line=$(tr -d '\r' < "$checksum_path" | head -n1)
+    if [[ -z "$line" ]]; then
         error "Checksum file is empty: $checksum_path"
     fi
+    read -r expected_checksum expected_name <<< "$line"
 
     if [[ ! "$expected_checksum" =~ ^[0-9A-Fa-f]{64}$ ]]; then
         error "Checksum file has invalid SHA-256 hash: $checksum_path"
@@ -670,6 +672,8 @@ verify_checksum_file() {
         if [[ "$expected_name" != "$archive_name" ]]; then
             error "Checksum file is for '$expected_name', expected '$archive_name'"
         fi
+    elif [[ -n "$archive_name" ]]; then
+        error "Checksum file contains no filename field; expected '$archive_name'"
     fi
 
     actual_checksum=$(compute_sha256 "$archive_path")

--- a/arcup/test_arcup.sh
+++ b/arcup/test_arcup.sh
@@ -119,6 +119,8 @@ test_checksum_validation() {
 
     printf '%s  other-asset.tar.gz\n' "$checksum" > "$checksum_file"
     expect_fail "checksum filename mismatch fails" verify_checksum_file "$archive" "$checksum_file" "$archive_name"
+    printf '%s\n' "$checksum" > "$checksum_file"
+    expect_fail "checksum file without filename field fails" verify_checksum_file "$archive" "$checksum_file" "$archive_name"
 }
 
 test_download_error_lists_assets() {

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -276,8 +276,11 @@ Also confirm that the SSH tunnel is still running.
 
 ### Prometheus is restarting with a permissions error
 
-If Prometheus logs include an error about `queries.active` or write permission
-under `/prometheus`, fix the ownership of the local data directory:
+The `compose.yaml` above runs Prometheus with `user: "0"` (root), which prevents
+this error in most configurations. If you removed `user: "0"` to run Prometheus
+as a non-root user, or if Prometheus logs an error about `queries.active` or write
+permission under `/prometheus`, restore ownership of the data directory to match
+Prometheus's default UID:
 
 ```sh
 sudo chown -R 65534:65534 "$ARC_MONITORING"/prometheus-data


### PR DESCRIPTION
## Summary

Two independent correctness fixes in a single PR.

### 1. `docs/monitoring.md` troubleshooting section contradicts `user: "0"` (#315)

The "Prometheus is restarting with a permissions error" section instructs operators to `chown -R 65534:65534` the data directory. However, the `compose.yaml` in the same guide sets `user: "0"` on the Prometheus service (root), so the described UID 65534 write-permission error cannot occur when following the guide as written. Updated the section to clarify that `user: "0"` prevents this error and that the `chown` step only applies when Prometheus runs as a non-root user.

### 2. `arcup/arcup` `verify_checksum_file` silently skips filename check for bare-hash inputs (#316)

When a `.sha256` file contains only a bare hash (no filename field), `expected_name` is empty and the `if [[ -n "$expected_name" ]]` guard skips filename validation entirely. The archive is accepted on hash match alone, silently violating the function's contract of verifying the checksum was intended for `$archive_name`. Added an `elif [[ -n "$archive_name" ]]` branch that errors explicitly in this case.

## Test plan

- [x] Docs-only change for monitoring.md
- [x] `verify_checksum_file` with a bare-hash `.sha256` now returns an error instead of silently passing

Fixes #315, #316
