### PR TITLE
fix(genesis): bound consensus params to uint16

### DIFF
--- a/scripts/genesis/ProtocolConfig.ts
+++ b/scripts/genesis/ProtocolConfig.ts
@@ -44,6 +44,8 @@ const PROTOCOL_CONFIG_CONTROLLER_STORAGE_LOCATION = 0x958f8fec699b51a1249f513ece
 const PAUSABLE_STORAGE_LOCATION = 0x0642d7922329a434cf4fd17a3c95eb692c24fd95f9f94d0b55420a5d895f4a00n
 
 const maxUint64 = 18446744073709551615n
+const maxUint16 = 65535n
+const schemaUint16 = schemaBigInt.min(0n).max(maxUint16)
 
 export const schemaProtocolConfig = z
   .object({
@@ -75,14 +77,14 @@ export const schemaProtocolConfig = z
     }),
     consensusParams: z
       .object({
-        timeoutProposeMs: schemaBigInt,
-        timeoutProposeDeltaMs: schemaBigInt,
-        timeoutPrevoteMs: schemaBigInt,
-        timeoutPrevoteDeltaMs: schemaBigInt,
-        timeoutPrecommitMs: schemaBigInt,
-        timeoutPrecommitDeltaMs: schemaBigInt,
-        timeoutRebroadcastMs: schemaBigInt,
-        targetBlockTimeMs: schemaBigInt,
+        timeoutProposeMs: schemaUint16,
+        timeoutProposeDeltaMs: schemaUint16,
+        timeoutPrevoteMs: schemaUint16,
+        timeoutPrevoteDeltaMs: schemaUint16,
+        timeoutPrecommitMs: schemaUint16,
+        timeoutPrecommitDeltaMs: schemaUint16,
+        timeoutRebroadcastMs: schemaUint16,
+        targetBlockTimeMs: schemaUint16,
       })
       .optional(),
   })

--- a/tests/unit/protocol-config-genesis.test.ts
+++ b/tests/unit/protocol-config-genesis.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Circle Internet Group, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai'
+import { schemaProtocolConfig } from '../../scripts/genesis/ProtocolConfig'
+
+const proxyAdmin = '0x0000000000000000000000000000000000000001'
+const owner = '0x0000000000000000000000000000000000000002'
+const controller = '0x0000000000000000000000000000000000000003'
+const pauser = '0x0000000000000000000000000000000000000004'
+
+const validConsensusParams = {
+  timeoutProposeMs: 3000n,
+  timeoutProposeDeltaMs: 500n,
+  timeoutPrevoteMs: 1000n,
+  timeoutPrevoteDeltaMs: 500n,
+  timeoutPrecommitMs: 1000n,
+  timeoutPrecommitDeltaMs: 500n,
+  timeoutRebroadcastMs: 2000n,
+  targetBlockTimeMs: 1000n,
+}
+
+const protocolConfig = {
+  proxy: {
+    admin: proxyAdmin,
+  },
+  owner,
+  controller,
+  pauser,
+  feeParams: {
+    alpha: 1n,
+    kRate: 1n,
+    inverseElasticityMultiplier: 1n,
+    minBaseFee: 0n,
+    maxBaseFee: 1_000_000n,
+    blockGasLimit: 30_000_000n,
+  },
+  consensusParams: validConsensusParams,
+}
+
+describe('ProtocolConfig genesis schema', () => {
+  it('accepts consensusParams at the uint16 upper bound', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...protocolConfig,
+        consensusParams: {
+          ...validConsensusParams,
+          timeoutProposeMs: 65535n,
+        },
+      }),
+    ).to.not.throw()
+  })
+
+  it('rejects consensusParams values above the uint16 upper bound', () => {
+    for (const key of Object.keys(validConsensusParams) as Array<keyof typeof validConsensusParams>) {
+      expect(
+        () =>
+          schemaProtocolConfig.parse({
+            ...protocolConfig,
+            consensusParams: {
+              ...validConsensusParams,
+              [key]: 65536n,
+            },
+          }),
+        `${key} should reject 65536`,
+      ).to.throw()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #320

This updates the genesis `ProtocolConfig` schema so `consensusParams` values are validated against the uint16 range before they are packed into the genesis storage slot.

The consensus params are packed as 8 x uint16 values in the `ProtocolConfig` storage slot. Previously, the schema accepted arbitrary bigint values for these fields, so values greater than 65535 could be accepted and then overflow into neighboring packed lanes.

---

## Changes

- Add a shared uint16 schema bound for genesis consensus params.
- Apply the bound to all packed `consensusParams` fields:
  - `timeoutProposeMs`
  - `timeoutProposeDeltaMs`
  - `timeoutPrevoteMs`
  - `timeoutPrevoteDeltaMs`
  - `timeoutPrecommitMs`
  - `timeoutPrecommitDeltaMs`
  - `timeoutRebroadcastMs`
  - `targetBlockTimeMs`
- Add unit coverage for:
  - accepting the uint16 upper bound, `65535`
  - rejecting `65536` for each packed `consensusParams` field

---

## Why

A genesis config should not accept values that cannot be represented correctly in the packed on-chain layout.

Before this fix, a value like `65536n` could pass schema validation and then encode as `0` in the intended uint16 lane while spilling into the next lane. This could silently produce a different consensus configuration than the one supplied in genesis.

---

## Tests

**Regression test before the fix:**

```bash
npx mocha -r ts-node/register ./tests/unit/protocol-config-genesis.test.ts
```

**Result before fix:**

1 passing
1 failing


**Failure:**

AssertionError: timeoutProposeMs should reject 65536: expected [Function] to throw an error


**After the fix:**

```bash
npx mocha -r ts-node/register ./tests/unit/protocol-config-genesis.test.ts
```

**Result:**

2 passing


**Formatting:**

```bash
npx prettier --config ./.prettierrc --check scripts/genesis/ProtocolConfig.ts tests/unit/protocol-config-genesis.test.ts
```

**Result:**

All matched files use Prettier code style!


**Lint:**

```bash
npx eslint scripts/genesis/ProtocolConfig.ts tests/unit/protocol-config-genesis.test.ts
```

**Result:**

passed


**Additional check attempted:**

```bash
npx tsc -p tsconfig.json --noEmit
```

**Result:**

failed on pre-existing repository-wide TypeScript errors unrelated to this PR. No errors from the new test file were reported in that output.


---

## Checklist

- [x] Tests pass — 2/2, confirmed failing before fix
- [x] Prettier / ESLint clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The bound only rejects values that were already invalid for the packed uint16 layout — any genesis config using valid values (0–65535) is unaffected. Verified the regression test fails against the old schema and passes with the fix, confirming it exercises the actual overflow path.

**Type:** 🐛 Bug fix
**Fixes:** #320