### PR TITLE
fix(genesis): reject zero block gas limit

### DIFF
--- a/scripts/genesis/ProtocolConfig.ts
+++ b/scripts/genesis/ProtocolConfig.ts
@@ -71,7 +71,7 @@ export const schemaProtocolConfig = z
       inverseElasticityMultiplier: schemaBigInt.min(0n).max(10000n),
       minBaseFee: schemaBigInt.min(0n).max(maxUint64),
       maxBaseFee: schemaBigInt.min(0n).max(maxUint64),
-      blockGasLimit: schemaBigInt.min(0n).max(maxUint64),
+      blockGasLimit: schemaBigInt.min(1n).max(maxUint64),
     }),
     consensusParams: z
       .object({

--- a/tests/unit/protocol-config-genesis.test.ts
+++ b/tests/unit/protocol-config-genesis.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Circle Internet Group, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai'
+import { schemaProtocolConfig } from '../../scripts/genesis/ProtocolConfig'
+
+const proxyAdmin = '0x0000000000000000000000000000000000000001'
+const owner = '0x0000000000000000000000000000000000000002'
+const controller = '0x0000000000000000000000000000000000000003'
+const pauser = '0x0000000000000000000000000000000000000004'
+const maxUint64 = 18446744073709551615n
+
+const protocolConfig = {
+  proxy: {
+    admin: proxyAdmin,
+  },
+  owner,
+  controller,
+  pauser,
+  feeParams: {
+    alpha: 1n,
+    kRate: 1n,
+    inverseElasticityMultiplier: 1n,
+    minBaseFee: 0n,
+    maxBaseFee: 1_000_000n,
+    blockGasLimit: 30_000_000n,
+  },
+}
+
+describe('ProtocolConfig genesis schema', () => {
+  it('accepts a positive block gas limit', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...protocolConfig,
+        feeParams: {
+          ...protocolConfig.feeParams,
+          blockGasLimit: 1n,
+        },
+      }),
+    ).to.not.throw()
+  })
+
+  it('rejects a zero block gas limit', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...protocolConfig,
+        feeParams: {
+          ...protocolConfig.feeParams,
+          blockGasLimit: 0n,
+        },
+      }),
+    ).to.throw()
+  })
+
+  it('rejects block gas limits above uint64', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...protocolConfig,
+        feeParams: {
+          ...protocolConfig.feeParams,
+          blockGasLimit: maxUint64 + 1n,
+        },
+      }),
+    ).to.throw()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #321

This updates the genesis `ProtocolConfig` schema so `blockGasLimit` must be greater than zero.

Previously, genesis validation accepted `blockGasLimit: 0n`:

blockGasLimit: schemaBigInt.min(0n).max(maxUint64)


but the runtime `ProtocolConfig` API rejects zero block gas limits. That allowed genesis configuration to bypass the same invariant enforced by normal protocol config updates.

---

## Changes

- Change the genesis `blockGasLimit` lower bound from `0n` to `1n`.
- Add unit coverage for:
  - accepting `blockGasLimit: 1n`
  - rejecting `blockGasLimit: 0n`
  - rejecting `blockGasLimit` above uint64

---

## Why

Genesis configuration should enforce the same basic invariant as runtime config updates. A zero block gas limit can create an unusable or inconsistent protocol configuration, and it should fail during genesis schema validation instead of being accepted.

---

## Tests

**Regression test before the fix:**

```bash
npx mocha -r ts-node/register ./tests/unit/protocol-config-genesis.test.ts
```

**Result before fix:**

2 passing
1 failing


**Failure:**

AssertionError: expected [Function] to throw an error


**After the fix:**

```bash
npx mocha -r ts-node/register ./tests/unit/protocol-config-genesis.test.ts
```

**Result:**

3 passing


**Formatting:**

```bash
npx prettier --config ./.prettierrc --check scripts/genesis/ProtocolConfig.ts tests/unit/protocol-config-genesis.test.ts
```

**Result:**

All matched files use Prettier code style!


**Lint:**

```bash
npx eslint scripts/genesis/ProtocolConfig.ts tests/unit/protocol-config-genesis.test.ts
```

**Result:**

passed


---

## Checklist

- [x] Tests pass — 3/3, confirmed failing before fix
- [x] Prettier / ESLint clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The bound only rejects `blockGasLimit: 0n`, which was already invalid per the runtime `ProtocolConfig` API — any genesis config using a positive gas limit is unaffected. Verified the regression test fails against the old schema and passes with the fix, confirming it exercises the actual invariant mismatch.

**Type:** 🐛 Bug fix
**Fixes:** #321