### PR TITLE
fix(arc-consensus-types): validate derived WebSocket port and preserve URL components in Display

### DIFF
--- a/crates/types/src/rpc_sync.rs
+++ b/crates/types/src/rpc_sync.rs
@@ -19,7 +19,7 @@
 use core::fmt;
 use std::str::FromStr;
 
-use url::Url;
+use url::{Host, Url};
 
 /// A parsed endpoint URL for RPC synchronization.
 ///
@@ -105,6 +105,21 @@ fn validate_ws_scheme(scheme: &str) -> Result<(), eyre::Report> {
     Ok(())
 }
 
+fn validate_derived_ws_port(http: &Url, has_ws_override: bool) -> Result<(), eyre::Report> {
+    if has_ws_override {
+        return Ok(());
+    }
+
+    if matches!(http.port(), Some(u16::MAX)) {
+        return Err(eyre::eyre!(
+            "Invalid HTTP URL port '{}': derived WebSocket port would overflow.",
+            u16::MAX
+        ));
+    }
+
+    Ok(())
+}
+
 /// Parses a WebSocket override in the format `<scheme>=<value>`.
 ///
 /// The value after `=` can be:
@@ -142,6 +157,7 @@ impl FromStr for SyncEndpointUrl {
             Url::parse(http_part).map_err(|e| eyre::eyre!("Failed to parse HTTP URL: {e}"))?;
 
         validate_http_scheme(http.scheme())?;
+        validate_derived_ws_port(&http, ws_part.is_some())?;
 
         let ws = ws_part
             .map(|part| parse_ws_override(part, &http))
@@ -153,17 +169,23 @@ impl FromStr for SyncEndpointUrl {
 
 impl fmt::Display for SyncEndpointUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let host = self.http.host_str().expect("validated host");
+        let host = host_for_display(&self.http);
         let http_port = self.http.port_or_known_default().expect("validated port");
         let ws_url = self.websocket();
-        let ws_host = ws_url.host_str().expect("validated host");
+        let ws_host = host_for_display(&ws_url);
 
-        write!(
-            f,
-            "{}://{host}:{http_port},{}=",
-            self.http.scheme(),
-            ws_url.scheme()
-        )?;
+        write!(f, "{}://{host}:{http_port}", self.http.scheme())?;
+        let http_path = self.http.path();
+        if http_path != "/" {
+            write!(f, "{http_path}")?;
+        }
+        if let Some(query) = self.http.query() {
+            write!(f, "?{query}")?;
+        }
+        if let Some(fragment) = self.http.fragment() {
+            write!(f, "#{fragment}")?;
+        }
+        write!(f, ",{}=", ws_url.scheme())?;
 
         let ws_path = ws_url.path();
         let has_path = ws_path != "/";
@@ -186,6 +208,13 @@ impl fmt::Display for SyncEndpointUrl {
         }
 
         Ok(())
+    }
+}
+
+fn host_for_display(url: &Url) -> String {
+    match url.host().expect("validated host") {
+        Host::Ipv6(addr) => format!("[{addr}]"),
+        host => host.to_string(),
     }
 }
 
@@ -347,6 +376,41 @@ mod tests {
             .unwrap();
         assert_eq!(url.http().as_str(), "https://example.com/");
         assert_eq!(url.websocket().as_str(), "wss://ws.example.com:1212/");
+    }
+
+    #[test]
+    fn parse_rejects_http_port_that_would_overflow_derived_websocket_port() {
+        let err = "http://localhost:65535"
+            .parse::<SyncEndpointUrl>()
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("derived WebSocket port would overflow"));
+    }
+
+    #[test]
+    fn display_preserves_http_path_and_query() {
+        let endpoint: SyncEndpointUrl =
+            "https://rpc.example.com/api/v1?key=value,wss=ws.example.com/websocket"
+                .parse()
+                .unwrap();
+
+        assert_eq!(
+            endpoint.to_string(),
+            "https://rpc.example.com:443/api/v1?key=value,wss=ws.example.com/websocket"
+        );
+        let reparsed: SyncEndpointUrl = endpoint.to_string().parse().unwrap();
+        assert_eq!(endpoint, reparsed);
+    }
+
+    #[test]
+    fn display_brackets_ipv6_hosts() {
+        let endpoint: SyncEndpointUrl = "http://[::1]:8545,ws=8546".parse().unwrap();
+
+        assert_eq!(endpoint.to_string(), "http://[::1]:8545,ws=8546");
+        let reparsed: SyncEndpointUrl = endpoint.to_string().parse().unwrap();
+        assert_eq!(endpoint, reparsed);
     }
 
     #[test]

--- a/crates/types/src/rpc_sync.rs
+++ b/crates/types/src/rpc_sync.rs
@@ -19,7 +19,7 @@
 use core::fmt;
 use std::str::FromStr;
 
-use url::{Host, Url};
+use url::Url;
 
 /// A parsed endpoint URL for RPC synchronization.
 ///
@@ -169,10 +169,10 @@ impl FromStr for SyncEndpointUrl {
 
 impl fmt::Display for SyncEndpointUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let host = host_for_display(&self.http);
+        let host = self.http.host_str().expect("validated host");
         let http_port = self.http.port_or_known_default().expect("validated port");
         let ws_url = self.websocket();
-        let ws_host = host_for_display(&ws_url);
+        let ws_host = ws_url.host_str().expect("validated host");
 
         write!(f, "{}://{host}:{http_port}", self.http.scheme())?;
         let http_path = self.http.path();
@@ -189,10 +189,11 @@ impl fmt::Display for SyncEndpointUrl {
 
         let ws_path = ws_url.path();
         let has_path = ws_path != "/";
+        let has_suffix = has_path || ws_url.query().is_some() || ws_url.fragment().is_some();
 
-        if ws_host != host || has_path {
-            // Include the host when it differs or when a path is present
-            // (a bare port + path like `443/websocket` mis-parses as a hostname)
+        if ws_host != host || has_suffix {
+            // Include the host when it differs or when extra URL components are
+            // present (a bare port plus path/query/fragment mis-parses as a host).
             write!(f, "{ws_host}")?;
             if let Some(ws_port) = ws_url.port() {
                 write!(f, ":{ws_port}")?;
@@ -206,15 +207,14 @@ impl fmt::Display for SyncEndpointUrl {
         if has_path {
             write!(f, "{ws_path}")?;
         }
+        if let Some(query) = ws_url.query() {
+            write!(f, "?{query}")?;
+        }
+        if let Some(fragment) = ws_url.fragment() {
+            write!(f, "#{fragment}")?;
+        }
 
         Ok(())
-    }
-}
-
-fn host_for_display(url: &Url) -> String {
-    match url.host().expect("validated host") {
-        Host::Ipv6(addr) => format!("[{addr}]"),
-        host => host.to_string(),
     }
 }
 
@@ -390,15 +390,15 @@ mod tests {
     }
 
     #[test]
-    fn display_preserves_http_path_and_query() {
+    fn display_preserves_http_and_websocket_path_query_and_fragment() {
         let endpoint: SyncEndpointUrl =
-            "https://rpc.example.com/api/v1?key=value,wss=ws.example.com/websocket"
+            "https://rpc.example.com/api/v1?key=value#http-fragment,wss=ws.example.com/websocket?token=abc#ws-fragment"
                 .parse()
                 .unwrap();
 
         assert_eq!(
             endpoint.to_string(),
-            "https://rpc.example.com:443/api/v1?key=value,wss=ws.example.com/websocket"
+            "https://rpc.example.com:443/api/v1?key=value#http-fragment,wss=ws.example.com/websocket?token=abc#ws-fragment"
         );
         let reparsed: SyncEndpointUrl = endpoint.to_string().parse().unwrap();
         assert_eq!(endpoint, reparsed);


### PR DESCRIPTION
## Summary

Refs #323.

This fixes `SyncEndpointUrl` cases that could either panic later when deriving the WebSocket URL or lose URL components during Display output and parse -> Display -> parse round-tripping.

---

## Changes

- Reject HTTP URLs with explicit port `65535` when no WebSocket override is provided.
- Preserve HTTP path, query, and fragment components in Display output.
- Preserve WebSocket override path, query, and fragment components in Display output.
- Keep the existing compact WebSocket override output for same-host/no-path cases.
- Keep IPv6 display behavior covered without adding custom host formatting; `url::Url::host_str()` already emits bracketed IPv6 hosts.
- Add regression tests for:
  - derived WebSocket port overflow
  - HTTP and WebSocket path/query/fragment preservation
  - existing IPv6 display behavior
  - existing round-trip behavior with path-based WebSocket overrides

---

## Why

Previously this parsed successfully:

http://localhost:65535/

but calling `websocket()` later would panic while deriving the WebSocket port through `checked_add(1).expect("port overflow")`.

Display also rebuilt endpoint strings from selected components instead of preserving the full parsed URL shape. The HTTP side dropped values such as `/api/v1?key=value`, and the WebSocket override side dropped query and fragment components such as `?token=abc#fragment`.

This moves the invalid derived-port case to parse-time validation and makes Display preserve the URL components currently covered by this PR. The broader Display serialization-vs-log-format decision and the userinfo / eager WebSocket derivation cases remain part of the wider #323 discussion.

---

## Verification

**Regression sabotage check:**
Temporarily removed the new derived-port validation call and ran:

cargo +1.94.0 test -p arc-consensus-types parse_rejects_http_port_that_would_overflow_derived_websocket_port -- --nocapture

Result: FAILED as expected — `called Result::unwrap_err() on an Ok value for http://localhost:65535/`

**Focused tests after restoring fix:**

cargo +1.94.0 test -p arc-consensus-types rpc_sync -- --nocapture

Result: 24 passed; 0 failed

**Formatting:**

cargo +1.94.0 fmt -p arc-consensus-types --check

Result: passed

**Lint:**

CARGO_BUILD_JOBS=1 cargo +1.94.0 clippy -p arc-consensus-types --all-targets -- -D warnings

Result: passed

**Whitespace:**

git diff --check

Result: passed

---

## Checklist

- [x] Tests pass — 24/24, confirmed regression test fails without the derived-port validation
- [x] cargo fmt / cargo clippy clean
- [x] git diff --check clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this partial fix only

---

## Risk & Impact

**Low.** The port-65535 rejection only affects URLs that would already panic at `websocket()` call time when no explicit WebSocket override is provided; this fix moves that failure to parse time. The Display fix is additive: it preserves HTTP and WebSocket path/query/fragment components that were previously silently dropped, while keeping the compact output for the existing same-host/no-path WebSocket override case.

This PR intentionally uses **Refs #323** rather than **Refs #323** because #323 now also tracks broader follow-up decisions around userinfo handling, eager WebSocket derivation, and whether Display should be treated as serialization or log/debug formatting.


**Refs:** #323.