### PR TITLE
docs: record EIP-2929 gas-estimation impact under v0.7.0

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -119,9 +119,9 @@ No breaking changes in this release.
 
 - **[EVM] EIP-2929 warm/cold pricing now applies to account loads performed by Arc precompiles.**
   - Old (`v0.6.x`): stateful precompile helpers did not charge EIP-2929 cold/warm account-access gas for loaded accounts.
-  - New (`v0.7.0`): account loads performed by Arc precompiles — including `CallFrom` (Memo) subcalls — charge that gas. Cost scales with the number of distinct cold accounts a call touches.
-  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node for precompile-adjacent paths (`Memo`, `Multicall3From`, `CallFrom`) can be too low on `v0.7.0` and fail on submission.
-  - Re-estimate against a `v0.7.0` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas. Note this is not gated behind a hardfork — the new pricing takes effect as soon as the node runs `v0.7.0`, so re-estimate at upgrade time rather than at the next fork. (`CallFrom` itself activates with `Zero7`, but that governs the precompile's availability, not the account-load pricing.)
+  - New (`v0.7.0`): account loads in NativeCoinAuthority mint / burn / transfer charge that gas. Cost scales with the number of distinct cold accounts a call touches.
+  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node can be too low. This applies chiefly to native fiat token mint / burn / transfer, which route through the NativeCoinAuthority precompile and are not hardfork-gated. `CallFrom` subcalls (`Memo`, `Multicall3From`) also charge cold account access, but that precompile only exists once `Zero7` is active.
+  - Re-estimate against a `v0.7.1` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas. Note this is not gated behind a hardfork — the new pricing takes effect as soon as the node runs `v0.7.1` or later, so re-estimate at upgrade time rather than at the next fork. (`CallFrom` itself activates with `Zero7`, but that governs the precompile's availability, not the NativeCoinAuthority account-load pricing.)
 
 ### For Validators
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -6,8 +6,8 @@ Each bullet is prefixed with a flag identifying the kind of breaking change:
 
 - `[CLI]` -- CLI flag added, renamed, removed, or made required.
 - `[Config]` -- default value, environment variable, or manifest field change.
-- `[Format]` -- log, metric label, or serialized output format change that breaks parsers.
 - `[EVM]` -- EVM / precompile gas-schedule or execution-cost change that affects estimates or limits.
+- `[Format]` -- log, metric label, or serialized output format change that breaks parsers.
 
 Entries are split by audience. A change appears under `### For Validators` when validator-mode operation must change; otherwise it appears under `### For Node Operators`. A change requiring both audiences to act appears in both sections (rare).
 
@@ -118,9 +118,10 @@ No breaking changes in this release.
   - Log parsers, alerting rules, and dashboards built against the previous mixed formats (EIP-55 checksummed, non-prefixed hex, etc.) must be updated.
 
 - **[EVM] EIP-2929 warm/cold pricing now applies to account loads performed by Arc precompiles.**
-  - Account loads performed by Arc precompiles — including `CallFrom` (Memo) subcalls — now charge EIP-2929 cold/warm account-access gas that `v0.6.x` did not. Cost scales with the number of distinct cold accounts a call touches.
+  - Old (`v0.6.x`): stateful precompile helpers did not charge EIP-2929 cold/warm account-access gas for loaded accounts.
+  - New (`v0.7.0`): account loads performed by Arc precompiles — including `CallFrom` (Memo) subcalls — charge that gas. Cost scales with the number of distinct cold accounts a call touches.
   - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node for precompile-adjacent paths (`Memo`, `Multicall3From`, `CallFrom`) can be too low on `v0.7.0` and fail on submission.
-  - Re-estimate against a `v0.7.0` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas; the new pricing activates with the `Zero7` hardfork.
+  - Re-estimate against a `v0.7.0` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas. Note this is not gated behind a hardfork — the new pricing takes effect as soon as the node runs `v0.7.0`, so re-estimate at upgrade time rather than at the next fork. (`CallFrom` itself activates with `Zero7`, but that governs the precompile's availability, not the account-load pricing.)
 
 ### For Validators
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -116,6 +116,11 @@ No breaking changes in this release.
   - Logs, metrics, and JSON-RPC responses now use a single canonical format (signatures continue to use Base64). EIP-55 checksums are not used; Prometheus labels are case-sensitive.
   - Log parsers, alerting rules, and dashboards built against the previous mixed formats (EIP-55 checksummed, non-prefixed hex, etc.) must be updated.
 
+- **EIP-2929 warm/cold pricing now applies to Arc precompile account loads and `CallFrom` subcalls.**
+  - Precompile account access and `CallFrom` (Memo) subcalls charge EIP-2929 cold/warm account-access gas that `v0.6.x` did not.
+  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node for precompile-adjacent paths (Memo / `CallFrom`, CCTP `TokenMessenger` calls) can be too low on `v0.7.0` and fail on submission.
+  - Re-estimate against a `v0.7.0` (or later) node. Consensus execution is unchanged for callers that already supply sufficient gas; only previously underpriced estimates break.
+
 ### For Validators
 
 - **[CLI] `arc-node-consensus`: `--validator` is required for block signing and voting.**

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -119,9 +119,9 @@ No breaking changes in this release.
 
 - **[EVM] EIP-2929 warm/cold pricing now applies to account loads performed by Arc precompiles.**
   - Old (`v0.6.x`): stateful precompile helpers did not charge EIP-2929 cold/warm account-access gas for loaded accounts.
-  - New (`v0.7.0`): account loads in NativeCoinAuthority mint / burn / transfer charge that gas. Cost scales with the number of distinct cold accounts a call touches.
-  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node can be too low. This applies chiefly to native fiat token mint / burn / transfer, which route through the NativeCoinAuthority precompile and are not hardfork-gated. `CallFrom` subcalls (`Memo`, `Multicall3From`) also charge cold account access, but that precompile only exists once `Zero7` is active.
-  - Re-estimate against a `v0.7.1` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas. Note this is not gated behind a hardfork — the new pricing takes effect as soon as the node runs `v0.7.1` or later, so re-estimate at upgrade time rather than at the next fork. (`CallFrom` itself activates with `Zero7`, but that governs the precompile's availability, not the NativeCoinAuthority account-load pricing.)
+  - New (`v0.7.0`): account loads in `NativeCoinAuthority` `mint` / `burn` / `transfer` charge that gas. Cost scales with the number of distinct cold accounts a call touches.
+  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node can be too low. This applies chiefly to native fiat token `mint` / `burn` / `transfer`, which route through the `NativeCoinAuthority` precompile and are gated behind `Zero6` (already active on live networks). `CallFrom` subcalls (`Memo`, `Multicall3From`) also charge cold account access, but that precompile only exists once `Zero7` is active.
+  - Re-estimate against a `v0.7.1` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas. Because `Zero6` is already open on live networks, the new pricing takes effect as soon as the node runs `v0.7.1` or later — re-estimate at upgrade time rather than at the next fork. (`CallFrom` itself activates with `Zero7`, but that governs the precompile's availability, not the `NativeCoinAuthority` account-load pricing.)
 
 ### For Validators
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -7,6 +7,7 @@ Each bullet is prefixed with a flag identifying the kind of breaking change:
 - `[CLI]` -- CLI flag added, renamed, removed, or made required.
 - `[Config]` -- default value, environment variable, or manifest field change.
 - `[Format]` -- log, metric label, or serialized output format change that breaks parsers.
+- `[EVM]` -- EVM / precompile gas-schedule or execution-cost change that affects estimates or limits.
 
 Entries are split by audience. A change appears under `### For Validators` when validator-mode operation must change; otherwise it appears under `### For Node Operators`. A change requiring both audiences to act appears in both sections (rare).
 
@@ -116,10 +117,10 @@ No breaking changes in this release.
   - Logs, metrics, and JSON-RPC responses now use a single canonical format (signatures continue to use Base64). EIP-55 checksums are not used; Prometheus labels are case-sensitive.
   - Log parsers, alerting rules, and dashboards built against the previous mixed formats (EIP-55 checksummed, non-prefixed hex, etc.) must be updated.
 
-- **EIP-2929 warm/cold pricing now applies to Arc precompile account loads and `CallFrom` subcalls.**
-  - Precompile account access and `CallFrom` (Memo) subcalls charge EIP-2929 cold/warm account-access gas that `v0.6.x` did not.
-  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node for precompile-adjacent paths (Memo / `CallFrom`, CCTP `TokenMessenger` calls) can be too low on `v0.7.0` and fail on submission.
-  - Re-estimate against a `v0.7.0` (or later) node. Consensus execution is unchanged for callers that already supply sufficient gas; only previously underpriced estimates break.
+- **[EVM] EIP-2929 warm/cold pricing now applies to account loads performed by Arc precompiles.**
+  - Account loads performed by Arc precompiles — including `CallFrom` (Memo) subcalls — now charge EIP-2929 cold/warm account-access gas that `v0.6.x` did not. Cost scales with the number of distinct cold accounts a call touches.
+  - `eth_estimateGas` results and hardcoded gas limits taken against a `v0.6.x` node for precompile-adjacent paths (`Memo`, `Multicall3From`, `CallFrom`) can be too low on `v0.7.0` and fail on submission.
+  - Re-estimate against a `v0.7.0` (or later) node. Transaction outcomes are unchanged for callers that already supply sufficient gas; the new pricing activates with the `Zero7` hardfork.
 
 ### For Validators
 


### PR DESCRIPTION
## Summary
- CHANGELOG v0.7.0 linked to `BREAKING_CHANGES.md#v070` for EIP-2929 precompile account-load gas impact, but that section had no entry.
- Documents that NativeCoinAuthority mint/burn/transfer now charge EIP-2929 cold/warm account-access gas (ships with the `v0.7.x` binary; not hardfork-gated).
- Notes CallFrom (`Memo` / `Multicall3From`) separately: different cold-access path, only live once Zero7 is active.
- Also covers the related CallFrom cold-access Fix from the same release; re-estimate target is `v0.7.1+` (no `v0.7.0` tag).

## Test plan
- [x] Confirm `CHANGELOG.md` EIP-2929 bullet still links to `#v070`
- [x] Confirm entry is under v0.7.0 For Node Operators
- [x] Confirm examples match `account_load_cost` call sites (NativeCoinAuthority), not CallFrom-only paths