### PR TITLE
fix(precompiles): restore Zero6 registration gate for PQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to arc-node are documented in this file.
 
+## [Unreleased]
+
+### Fixes
+
+- [EL] Restore Zero6 registration gate for the PQ precompile (regressed in v0.8.0); pre-Zero6 blocks no longer execute the verifier on replay
+
 ## [v0.8.0]
 
 **Changes:** [v0.7.3...v0.8.0](https://github.com/circlefin/arc-node/compare/v0.7.3...v0.8.0) -- [release notes](https://github.com/circlefin/arc-node/releases/tag/v0.8.0)

--- a/crates/pq-precompile/src/lib.rs
+++ b/crates/pq-precompile/src/lib.rs
@@ -21,7 +21,7 @@ use revm_interpreter::gas::KECCAK256WORD;
 use revm_interpreter::Gas;
 use slh_dsa::{signature::Verifier, Sha2_128s, Signature, VerifyingKey as SlhDsaVerifyingKey};
 
-/// PQ precompile address — SLH-DSA-SHA2-128s signature verifier.
+/// PQ precompile address — SLH-DSA-SHA2-128s signature verifier (Zero6-gated).
 pub const PQ_ADDRESS: Address = address!("1800000000000000000000000000000000000004");
 
 /// Base gas for SLH-DSA-SHA2-128s verification.

--- a/crates/pq-precompile/src/lib.rs
+++ b/crates/pq-precompile/src/lib.rs
@@ -21,7 +21,7 @@ use revm_interpreter::gas::KECCAK256WORD;
 use revm_interpreter::Gas;
 use slh_dsa::{signature::Verifier, Sha2_128s, Signature, VerifyingKey as SlhDsaVerifyingKey};
 
-/// PQ precompile address — SLH-DSA-SHA2-128s signature verifier (Zero6-gated).
+/// PQ precompile address — SLH-DSA-SHA2-128s signature verifier.
 pub const PQ_ADDRESS: Address = address!("1800000000000000000000000000000000000004");
 
 /// Base gas for SLH-DSA-SHA2-128s verification.

--- a/crates/precompiles/src/precompile_provider.rs
+++ b/crates/precompiles/src/precompile_provider.rs
@@ -22,7 +22,7 @@ use crate::pq::{run_pq, PQ_ADDRESS};
 use crate::system_accounting::{run_system_accounting, SYSTEM_ACCOUNTING_ADDRESS};
 use alloy_evm::precompiles::PrecompilesMap;
 use alloy_primitives::Address;
-use arc_execution_config::hardforks::ArcHardforkFlags;
+use arc_execution_config::hardforks::{ArcHardfork, ArcHardforkFlags};
 use reth_ethereum::evm::revm::precompile::PrecompileSpecId;
 use reth_ethereum::evm::revm::precompile::Precompiles;
 use reth_evm::precompiles::DynPrecompile;
@@ -60,10 +60,16 @@ impl ArcPrecompileProvider {
                 PrecompileId::Custom("SYSTEM_ACCOUNTING".into()),
                 move |input| run_system_accounting(input, hardfork_flags),
             )),
-            PQ_ADDRESS => Some(DynPrecompile::new_stateful(
-                PrecompileId::Custom("PQ".into()),
-                move |input| run_pq(input, hardfork_flags),
-            )),
+            PQ_ADDRESS => {
+                // Only register PQ precompile if Zero6 hardfork is active
+                if !hardfork_flags.is_active(ArcHardfork::Zero6) {
+                    return None;
+                }
+                Some(DynPrecompile::new_stateful(
+                    PrecompileId::Custom("PQ".into()),
+                    move |input| run_pq(input, hardfork_flags),
+                ))
+            }
             _ => handle_unknown_precompile(address),
         });
         precompile_map
@@ -117,15 +123,28 @@ mod tests {
     }
 
     #[test]
-    fn test_pq_precompile_available() {
+    fn test_pq_precompile_available_with_zero6() {
+        let precompiles = ArcPrecompileProvider::create_precompiles_map(
+            SpecId::PRAGUE,
+            ArcHardforkFlags::with(&[ArcHardfork::Zero6]),
+        );
+
+        assert!(
+            precompiles.get(&PQ_ADDRESS).is_some(),
+            "PQ precompile should be available when Zero6 is active"
+        );
+    }
+
+    #[test]
+    fn test_pq_precompile_not_available_without_zero6() {
         let precompiles = ArcPrecompileProvider::create_precompiles_map(
             SpecId::PRAGUE,
             ArcHardforkFlags::default(),
         );
 
         assert!(
-            precompiles.get(&PQ_ADDRESS).is_some(),
-            "PQ precompile should be available"
+            precompiles.get(&PQ_ADDRESS).is_none(),
+            "PQ precompile should NOT be available without Zero6"
         );
     }
 


### PR DESCRIPTION
﻿## Summary
Restores the v0.7.x Zero6 registration-time gate for the PQ precompile that was dropped in the v0.8.0 sync, and puts back the matched availability tests.

Per review from @osr21 on the previous docs-only approach: the `(Zero6-gated)` comment was the last correct statement of intended behavior. `_hardfork_flags` looked unused because the guard that read it was deleted, not because gating was never meant to exist.

## Changes
1. Restore the `ArcHardfork::Zero6` check in `create_precompiles_map` for `PQ_ADDRESS`
2. Restore `test_pq_precompile_available_with_zero6` / `test_pq_precompile_not_available_without_zero6`
3. Keep the `(Zero6-gated)` doc on `PQ_ADDRESS`

## Note
Public PRs here are reference implementations for Circle's internal sync. Happy to close or adjust if maintainers prefer a different direction after security triage on #293.

Resolves #293 (option 2 from the issue).
