### PR TITLE
fix(node): reject non-http transaction relay URLs

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -400,9 +400,14 @@ fn build_tx_relays(ext: &ArcExtraCli) -> eyre::Result<Vec<String>> {
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .map(|s| {
-            url::Url::parse(s)
-                .map(|_| s.to_string())
-                .map_err(|e| eyre::eyre!("invalid --arc.tx.relays entry {s:?}: {e}"))
+            let url = url::Url::parse(s)
+                .map_err(|e| eyre::eyre!("invalid --arc.tx.relays entry {s:?}: {e}"))?;
+            if !matches!(url.scheme(), "http" | "https") {
+                return Err(eyre::eyre!(
+                    "invalid --arc.tx.relays entry {s:?}: transaction relay upstreams must use HTTP or HTTPS"
+                ));
+            }
+            Ok(s.to_string())
         })
         .collect()
 }
@@ -1028,10 +1033,10 @@ mod tests {
     #[test]
     fn test_build_tx_relays_parses_csv_in_order() {
         let relays =
-            tx_relays_from_args(&["--arc.tx.relays", "http://a:8545,http://b:8545"]).unwrap();
+            tx_relays_from_args(&["--arc.tx.relays", "http://a:8545,https://b.example"]).unwrap();
         assert_eq!(
             relays,
-            vec!["http://a:8545".to_string(), "http://b:8545".to_string()]
+            vec!["http://a:8545".to_string(), "https://b.example".to_string()]
         );
     }
 
@@ -1045,6 +1050,23 @@ mod tests {
     fn test_build_tx_relays_rejects_invalid_url() {
         let err = tx_relays_from_args(&["--arc.tx.relays", "not-a-url"]).unwrap_err();
         assert!(err.to_string().contains("invalid --arc.tx.relays entry"));
+    }
+
+    #[test]
+    fn test_build_tx_relays_rejects_non_http_urls() {
+        for relay in [
+            "file:///tmp/upstream",
+            "ftp://relay.example",
+            "ws://relay.example",
+            "wss://relay.example",
+        ] {
+            let err = tx_relays_from_args(&["--arc.tx.relays", relay])
+                .expect_err("transaction relay upstreams must use HTTP or HTTPS");
+            assert!(
+                err.to_string().contains("must use HTTP or HTTPS"),
+                "unexpected error for {relay}: {err}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #335

- Validate the transport scheme of every `--arc.tx.relays` entry
- Accept only `http` and `https` relay URLs
- Reject syntactically valid but unsupported `file`, `ftp`, `ws`, and `wss` URLs during startup
- Preserve relay ordering, whitespace trimming, blank-entry handling, and existing malformed-URL errors
- Add focused regression coverage for supported and unsupported schemes

---

## Problem

`build_tx_relays()` previously validated relay entries using only:

url::Url::parse(s)

This verifies URL syntax but not compatibility with the downstream transport.

As a result, configurations such as:

--arc.tx.relays file:///tmp/upstream

were accepted and returned as valid relay entries.

The downstream implementation constructs each relay with an explicitly HTTP-based client:

RpcClient::new_http_with_client(...)

using `reqwest::Client`. Unsupported schemes therefore failed only when transaction forwarding was attempted, rather than being rejected during startup validation.

---

## Changes

`build_tx_relays()` now:

1. parses each relay URL as before;
2. checks the parsed URL scheme;
3. accepts only `http` and `https`;
4. returns an `invalid --arc.tx.relays entry` error for unsupported schemes;
5. preserves the original trimmed URL and configured relay order.

No forwarding, failover, timeout, or RPC client behavior was changed.

---

## Regression Coverage

The existing relay-order test now verifies a mixed HTTP/HTTPS list:

http://a:8545,https://b.example

A new regression test verifies that the following schemes are rejected:

file:///tmp/upstream
ftp://relay.example
ws://relay.example
wss://relay.example

The existing tests for malformed URLs, trimming, blank entries, relay order, timeout parsing, and `--rpc.forwarder` conflicts remain in place.

---

## RED Verification

Before the production fix, the unsupported-scheme regression test failed:

transaction relay upstreams must use HTTP or HTTPS:
["file:///tmp/upstream"]

test tests::test_build_tx_relays_rejects_non_http_urls ... FAILED

The HTTP/HTTPS acceptance test continued to pass.

---

## How to Test

cargo +1.94.0 test -p arc-node-execution transaction_relay -- --nocapture
cargo +1.94.0 test -p arc-node-execution --bin arc-node-execution --tests
cargo clippy -p arc-node-execution --bin arc-node-execution --tests -- -D warnings
cargo fmt -p arc-node-execution -- --check
git diff --check

Results:
- Focused transaction-relay tests: 5 passed
- Complete arc-node-execution binary tests: 65 passed
- cargo clippy: passed
- cargo fmt: passed
- git diff --check: passed

Note: The final linked test binary was built with reduced linker memory usage because the standard test link exceeded the available WSL memory:

CARGO_BUILD_JOBS=1 cargo +1.94.0 rustc \
  -p arc-node-execution \
  --bin arc-node-execution \
  --profile test \
  -- \
  -C debuginfo=0 \
  -C link-arg=-Wl,--no-keep-memory

Local verification used Rust 1.94.0 because the local pinned 1.93.0 installation is currently broken. CI should provide the authoritative pinned-toolchain result.

---

## Scope and Risk

Risk is low.

The change is limited to the CLI configuration boundary in:

crates/node/src/main.rs

It does not alter:

- transaction forwarding
- relay failover or sticky selection
- request timeout behavior
- response handling
- RPC client construction
- consensus or protocol behavior

---

## Checklist

- [x] Bug reproduced on current main
- [x] Regression test confirmed failing before the fix
- [x] HTTP and HTTPS relay URLs remain accepted
- [x] Unsupported schemes are rejected during startup
- [x] Focused and complete binary tests pass
- [x] Formatting and clippy checks pass
- [x] No unrelated files changed
- [x] Follows Conventional Commits
- [x] Independent read-only review: approved with no blocking findings

---

## Impact

Type: 🐛 Bug fix
Fixes: #335
