### PR TITLE
fix(consensus): reject execution WebSocket endpoint with IPC

### DIFF
--- a/crates/malachite-cli/src/cmd/start.rs
+++ b/crates/malachite-cli/src/cmd/start.rs
@@ -694,13 +694,14 @@ impl StartCmd {
         let has_ipc_options = self.eth_socket.is_some() || self.execution_socket.is_some();
         let has_rpc_options = self.eth_rpc_endpoint.is_some()
             || self.execution_endpoint.is_some()
+            || self.execution_ws_endpoint.is_some()
             || self.execution_jwt.is_some();
 
         if has_ipc_options && has_rpc_options {
             return Err(eyre::eyre!(
                 "Conflicting options detected: Cannot specify both IPC and RPC options simultaneously.\n\
                 IPC options: --eth-socket, --execution-socket\n\
-                RPC options: --eth-rpc-endpoint, --execution-endpoint, --execution-jwt\n\
+                RPC options: --eth-rpc-endpoint, --execution-endpoint, --execution-ws-endpoint, --execution-jwt\n\
                 Please choose either IPC (for local communication) or RPC (for remote communication)."
             ));
         }
@@ -938,6 +939,21 @@ mod tests {
 
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("Conflicting options detected"));
+    }
+
+    #[test]
+    fn validate_err_when_mixing_ipc_and_execution_ws_endpoint() {
+        let mut cmd = new_start_cmd();
+        cmd.eth_socket = Some("/tmp/reth.ipc".to_string());
+        cmd.execution_socket = Some("/tmp/reth-auth.ipc".to_string());
+        cmd.execution_ws_endpoint = Some(dummy_url());
+
+        let err = cmd
+            .validate()
+            .expect_err("--execution-ws-endpoint must conflict with IPC transport options");
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Conflicting options detected"));
+        assert!(err_msg.contains("--execution-ws-endpoint"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #338

Reject consensus CLI configurations that combine IPC transport options with --execution-ws-endpoint.

The WebSocket endpoint is an RPC transport option, but it was omitted from the IPC/RPC conflict check. As a result, a complete IPC configuration could be accepted together with an execution WebSocket endpoint, after which the IPC configuration took precedence and the explicitly supplied WebSocket endpoint was silently ignored.

---

## Problem

StartCmd::validate() classifies these fields as RPC options when checking for conflicts with IPC:

- --eth-rpc-endpoint
- --execution-endpoint
- --execution-jwt

However, it omitted:

- --execution-ws-endpoint

This was inconsistent with the later uses_rpc_transport check, which already treats execution_ws_endpoint as an RPC transport option.

When both IPC sockets and --execution-ws-endpoint were configured:

1. CLI validation succeeded.
2. StartConfig::engine_config() selected EngineConfig::Ipc.
3. The supplied WebSocket endpoint was not used.
4. The node could start with an explicit configuration value silently ignored.

---

## Changes

- Include execution_ws_endpoint in the RPC option set used by the IPC/RPC conflict validation.
- Include --execution-ws-endpoint in the conflict error's list of RPC options.
- Add a regression test covering a complete IPC configuration combined with an explicit execution WebSocket endpoint.

---

## Regression Coverage

The new test configures:

--eth-socket /tmp/reth.ipc
--execution-socket /tmp/reth-auth.ipc
--execution-ws-endpoint <URL>

and verifies that:

- validation rejects the configuration;
- the error reports an IPC/RPC conflict;
- the error identifies --execution-ws-endpoint as an RPC option.

The regression test was confirmed to fail against the previous implementation before the validation fix was applied.

---

## How to Test

cargo +1.94.0 test \
  -p arc-node-consensus-cli \
  validate_err_when_mixing_ipc_and_execution_ws_endpoint \
  -- --nocapture

Result:

1 passed; 0 failed

Full affected package:

cargo +1.94.0 test -p arc-node-consensus-cli

Result:

89 passed; 0 failed

Additional checks:

cargo +1.94.0 fmt -p arc-node-consensus-cli -- --check
cargo +1.94.0 clippy -p arc-node-consensus-cli --all-targets -- -D warnings
git diff --check

All checks passed.

---

## Scope and Risk

This is limited to CLI validation and its regression coverage.

It does not change:

- IPC connection behavior;
- RPC connection behavior;
- WebSocket endpoint derivation;
- EngineConfig construction;
- consensus or protocol behavior.

Existing valid IPC-only and RPC-only configurations are unaffected.

---

## Duplicate Check

Open and closed issues and pull requests were searched using the affected flag names, transport combinations, and conflict message. No direct duplicate or existing implementation was found.

Issue #294 and PR #295 concern separated-host deprecation wording and do not address this validation gap.

---

## Checklist

- [x] The bug was reproduced on current main.
- [x] A regression test was added and proven to fail before the fix.
- [x] The implementation is limited to the affected validation path.
- [x] Focused and package tests pass.
- [x] Formatting and Clippy checks pass.
- [x] No protocol, persistence, API, or dependency changes are included.
- [x] The change was reviewed independently.
- [x] Follows Conventional Commits

---

## Impact

Type: 🐛 Bug fix
Fixes: #338
