### PR TITLE
fix(spammer): validate WebSocket targets

### DIFF
--- a/crates/spammer/src/main.rs
+++ b/crates/spammer/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
     let target_ws_urls = match cli.command {
         TargetCommand::Ws { targets } => {
             let target_nodes = targets.unwrap_or_else(|| vec![DEFAULT_WS_TARGET.to_string()]);
-            ws_urls_from_strings(target_nodes)
+            ws_urls_from_strings(target_nodes)?
         }
         TargetCommand::Nodes {
             nodes_path,
@@ -230,20 +230,31 @@ fn write_atomic(contents: &str, path: &Path, label: &str) -> Result<()> {
 }
 
 // Build the WebSocket URLs of the target nodes from the list of IP addresses and ports
-fn ws_urls_from_strings(target_nodes: Vec<String>) -> Vec<(String, Url)> {
+fn ws_urls_from_strings(target_nodes: Vec<String>) -> Result<Vec<(String, Url)>> {
     target_nodes
         .into_iter()
-        .map(|s| (s.clone(), ws_url_from_str(s)))
+        .map(|target| {
+            let url = ws_url_from_str(&target)?;
+            Ok((target, url))
+        })
         .collect()
 }
 
-fn ws_url_from_str(ip_port: String) -> Url {
-    let url_str = if !ip_port.starts_with("ws://") {
-        format!("ws://{ip_port}")
+fn ws_url_from_str(target: &str) -> Result<Url> {
+    let url_str = if target.contains("://") {
+        target.to_string()
     } else {
-        ip_port
+        format!("ws://{target}")
     };
-    Url::parse(&url_str).unwrap()
+    let url =
+        Url::parse(&url_str).wrap_err_with(|| format!("Invalid --targets entry {target:?}"))?;
+    if !matches!(url.scheme(), "ws" | "wss") {
+        eyre::bail!(
+            "Invalid --targets entry {target:?}: unsupported scheme {:?}; expected ws:// or wss://",
+            url.scheme()
+        );
+    }
+    Ok(url)
 }
 
 // Read the file with node metadata and obtain the WebSocket URLs of the target nodes
@@ -313,14 +324,34 @@ mod tests {
 
     #[test]
     fn ws_url_from_str_adds_ws_scheme_if_missing() {
-        let url = ws_url_from_str("127.0.0.1:8546".to_string());
+        let url = ws_url_from_str("127.0.0.1:8546").unwrap();
         assert_eq!(url.as_str(), "ws://127.0.0.1:8546/");
     }
 
     #[test]
     fn ws_url_from_str_parses_endpoint() {
-        let url = ws_url_from_str("ws://127.0.0.1:8546".to_string());
+        let url = ws_url_from_str("ws://127.0.0.1:8546").unwrap();
         assert_eq!(url.as_str(), "ws://127.0.0.1:8546/");
+    }
+
+    #[test]
+    fn ws_url_from_str_preserves_secure_websocket_scheme() {
+        let url = ws_url_from_str("wss://rpc.example:8546").unwrap();
+        assert_eq!(url.as_str(), "wss://rpc.example:8546/");
+    }
+
+    #[test]
+    fn ws_url_from_str_rejects_invalid_target_without_panicking() {
+        let err = ws_url_from_str("\u{200d}.example:8546").unwrap_err();
+        assert!(err.to_string().contains("Invalid --targets entry"));
+    }
+
+    #[test]
+    fn ws_url_from_str_rejects_unsupported_scheme() {
+        let err = ws_url_from_str("http://rpc.example:8545").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("unsupported scheme \"http\""));
+        assert!(message.contains("expected ws:// or wss://"));
     }
 
     #[test]
@@ -328,7 +359,8 @@ mod tests {
         let urls = ws_urls_from_strings(vec![
             "127.0.0.1:8546".to_string(),
             "ws://127.0.0.1:9546".to_string(),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(urls.len(), 2);
         assert_eq!(urls[0].0, "127.0.0.1:8546");


### PR DESCRIPTION
## Summary

Fixes #347

- Preserve explicit `wss://` targets in the spammer's direct WebSocket target path.
- Continue adding `ws://` to bare `host:port` targets.
- Reject unsupported explicit schemes instead of rewriting them into misleading WebSocket URLs.
- Propagate URL parsing failures as normal CLI errors instead of panicking through `unwrap()`.
- Add focused regression coverage for secure WebSocket targets and invalid target handling.

---

## Problem

`ws_url_from_str()` previously recognized only the literal `ws://` prefix:

```rust
let url_str = if !ip_port.starts_with("ws://") {
    format!("ws://{ip_port}")
} else {
    ip_port
};
Url::parse(&url_str).unwrap()
```

This caused two related failures.

First, an explicit secure WebSocket target such as:

```text
wss://rpc.example:8546
```

was prefixed again and parsed as:

```text
ws://wss://rpc.example:8546
```

which normalized to the wrong endpoint:

```text
ws://wss//rpc.example:8546
```

Second, invalid target values reached `Url::parse(...).unwrap()` and terminated the process with a panic. An invalid IDNA hostname produced:

```text
called `Result::unwrap()` on an `Err` value: IdnaError
```

---

## Changes

The direct-target parsing path now:

1. preserves inputs with an explicit URL scheme for validation;
2. adds `ws://` only to schemeless targets such as `127.0.0.1:8546`;
3. parses the resulting URL without `unwrap()`;
4. accepts only `ws` and `wss` schemes;
5. reports the original `--targets` entry in parsing and scheme errors;
6. propagates errors through `ws_urls_from_strings()` and `main()`.

The nodes-metadata path is unchanged because it already deserializes `execution.ws_url` directly as `Url` and does not call `ws_url_from_str()`.

---

## Regression Coverage

Added tests verifying that:

- bare `host:port` targets still receive `ws://`;
- explicit `ws://` targets remain valid;
- explicit `wss://` targets are preserved;
- invalid IDNA targets return a contextual error without panicking;
- unsupported explicit schemes such as `http://` are rejected.

Existing direct-target list and nodes-metadata tests remain in place.

---

## RED Verification

Before the production fix, the focused regression tests failed on current `main`:

```text
secure WebSocket target:
  left: "ws://wss//rpc.example:8546"
 right: "wss://rpc.example:8546/"

invalid target:
called `Result::unwrap()` on an `Err` value: IdnaError

test result: FAILED. 2 passed; 2 failed; 8 filtered out
```

The real CLI entry point also panicked with exit code 101 before attempting a network connection.

---

## How to Test

Focused target parsing tests:

```bash
cargo +1.94.0 test \
  -p spammer \
  --bin spammer \
  ws_url_from_str_ \
  -- --nocapture
```

Result:

```text
5 passed; 0 failed
```

Complete spammer package:

```bash
cargo +1.94.0 test -p spammer
```

Results:

```text
library tests: 72 passed; 0 failed
binary tests: 13 passed; 0 failed
doc tests: 0 failed
```

Additional checks:

```bash
cargo +1.94.0 clippy -p spammer --all-targets -- -D warnings
cargo +1.94.0 fmt -p spammer -- --check
git diff --check
```

All checks passed.

The fixed binary was also invoked with the same invalid IDNA target. It now exits normally with code 1 and reports:

```text
Error: Invalid --targets entry "\u{200d}.example:8546"

Caused by:
    invalid international domain name
```

No panic text is emitted.

Local verification used Rust 1.94.0 because the local pinned 1.93.0 installation has a `cargo-clippy` component conflict. CI should provide the authoritative pinned-toolchain result.

---

## Scope and Risk

Risk is low. The change is limited to direct spammer WebSocket target parsing in:

```text
crates/spammer/src/main.rs
```

It does not change:

- WebSocket client connection or retry behavior;
- transaction generation or sending;
- nodes metadata parsing;
- consensus or protocol behavior;
- dependency versions.

The existing bare `host:port` and explicit `ws://` forms remain supported.

---

## Duplicate Check

Open and closed issues and pull requests were searched using the issue number, helper name, affected schemes, panic text, and target-parsing terms. No duplicate PR or existing implementation was found.

---

## Checklist

- [x] Bug reproduced on current `main`
- [x] Regression tests confirmed failing before the fix
- [x] `wss://` targets are preserved
- [x] Invalid targets return errors without panicking
- [x] Unsupported explicit schemes are rejected
- [x] Focused and complete package tests pass
- [x] Formatting and Clippy checks pass
- [x] Real CLI error path verified
- [x] No unrelated files changed
- [x] Independent read-only review found no blocking issues
- [x] Follows Conventional Commits

---

## Impact

Type: 🐛 Bug fix

Fixes: #347
