### PR TITLE
fix(spammer): reject rates above limiter resolution

### DIFF
--- a/crates/spammer/src/cli.rs
+++ b/crates/spammer/src/cli.rs
@@ -21,6 +21,7 @@ use clap::Args;
 use crate::{
     accounts::PartitionMode,
     config::{Erc20FnWeights, GuzzlerFnWeights, TxTypeMix},
+    rate_limiter::MAX_TPS,
     Config,
 };
 
@@ -83,7 +84,7 @@ pub struct SpammerArgs {
     #[clap(short = 'n', long, default_value_t = defaults::NUM_TXS, global = true)]
     pub num_txs: u64,
     /// Number of transactions to send per second (all generators combined)
-    #[clap(short = 'r', long, default_value_t = defaults::RATE, global = true, value_parser = clap::value_parser!(u64).range(1..))]
+    #[clap(short = 'r', long, default_value_t = defaults::RATE, global = true, value_parser = clap::value_parser!(u64).range(1..=MAX_TPS))]
     pub rate: u64,
     /// Maximum time in seconds to send transactions (applies to all generators) (0 for no limit)
     #[clap(short = 't', long, default_value_t = defaults::TIME, global = true)]

--- a/crates/spammer/src/config.rs
+++ b/crates/spammer/src/config.rs
@@ -16,7 +16,7 @@
 
 use std::path::PathBuf;
 
-use crate::accounts::PartitionMode;
+use crate::{accounts::PartitionMode, rate_limiter::MAX_TPS};
 use color_eyre::eyre::{self, Result};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -356,6 +356,12 @@ impl Config {
         if self.num_generators == 0 {
             eyre::bail!("num_generators must be greater than 0");
         }
+        if self.max_rate > MAX_TPS {
+            eyre::bail!(
+                "--rate ({}) exceeds the maximum supported rate ({MAX_TPS})",
+                self.max_rate
+            );
+        }
         if !self.max_num_accounts.is_multiple_of(self.num_generators) {
             eyre::bail!(
                 "Expected max_num_accounts ({}) to be divisible by num_generators ({})",
@@ -459,6 +465,28 @@ mod tests {
             tx_latency: false,
             csv_dir: None,
         }
+    }
+
+    #[test]
+    fn config_accepts_max_supported_rate() {
+        Config {
+            max_rate: MAX_TPS,
+            ..default_config()
+        }
+        .validate()
+        .expect("maximum representable rate should be supported");
+    }
+
+    #[test]
+    fn config_rejects_rate_above_supported_max() {
+        let err = Config {
+            max_rate: MAX_TPS + 1,
+            ..default_config()
+        }
+        .validate()
+        .expect_err("oversized rate must be rejected");
+        assert!(err.to_string().contains("--rate"));
+        assert!(err.to_string().contains(&MAX_TPS.to_string()));
     }
 
     #[test]

--- a/crates/spammer/src/main.rs
+++ b/crates/spammer/src/main.rs
@@ -477,6 +477,20 @@ mod tests {
     }
 
     #[test]
+    fn cli_rejects_rate_above_supported_max() {
+        let max_rate = 1_000_000_000_u64.to_string();
+        Cli::try_parse_from(["spammer", "--rate", max_rate.as_str(), "ws"])
+            .expect("maximum representable rate should be accepted");
+
+        let oversized_rate = 1_000_000_001_u64.to_string();
+        let err = match Cli::try_parse_from(["spammer", "--rate", oversized_rate.as_str(), "ws"]) {
+            Ok(_) => panic!("rate above the supported maximum must be rejected"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
     fn cli_parses_fire_and_forget_flag() {
         // Default: fire_and_forget is false (backpressure is the default)
         let cli = Cli::try_parse_from(["spammer", "ws"]).expect("parsing ws subcommand");

--- a/crates/spammer/src/rate_limiter.rs
+++ b/crates/spammer/src/rate_limiter.rs
@@ -17,7 +17,12 @@
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use color_eyre::eyre::{self, Result, WrapErr};
 use governor::{Jitter, Quota};
+
+/// Highest rate `governor` can represent without rounding its per-token
+/// replenish interval down to zero nanoseconds.
+pub(crate) const MAX_TPS: u64 = 1_000_000_000;
 
 /// Token-bucket rate limiter for transaction sending.
 ///
@@ -32,22 +37,28 @@ pub(crate) struct RateLimiter {
 }
 
 impl RateLimiter {
-    pub fn new(tps: u64, max_num_txs: u64, num_senders: usize) -> Self {
-        let tps_u32 = u32::try_from(tps).expect("TPS must fit in u32");
-        let tps_nz = NonZeroU32::new(tps_u32).expect("TPS must be > 0");
+    pub fn new(tps: u64, max_num_txs: u64, num_senders: usize) -> Result<Self> {
+        if tps > MAX_TPS {
+            eyre::bail!("rate {tps} exceeds the maximum supported rate {MAX_TPS}");
+        }
+        let tps_u32 = u32::try_from(tps)
+            .wrap_err_with(|| format!("rate {tps} exceeds the maximum supported rate {MAX_TPS}"))?;
+        let tps_nz =
+            NonZeroU32::new(tps_u32).ok_or_else(|| eyre::eyre!("rate must be greater than 0"))?;
         let burst = (tps / num_senders.max(1) as u64).max(1);
-        let burst_nz = NonZeroU32::new(u32::try_from(burst).expect("burst must fit in u32"))
-            .expect("burst must be > 0");
+        let burst_u32 = u32::try_from(burst).wrap_err("rate limiter burst must fit in u32")?;
+        let burst_nz = NonZeroU32::new(burst_u32)
+            .ok_or_else(|| eyre::eyre!("rate limiter burst must be greater than 0"))?;
         let quota = Quota::per_second(tps_nz).allow_burst(burst_nz);
         let limiter = governor::RateLimiter::direct(quota);
         // Uniformly random jitter up to half the interval
         let jitter = Jitter::up_to(quota.replenish_interval() / 2);
-        Self {
+        Ok(Self {
             limiter,
             jitter,
             max_num_txs,
             total_counter: AtomicU64::new(0),
-        }
+        })
     }
 
     /// Wait until the rate limiter permits the next send.
@@ -60,5 +71,25 @@ impl RateLimiter {
         }
         let prev = self.total_counter.fetch_add(1, Ordering::Relaxed);
         prev < self.max_num_txs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_accepts_max_supported_rate() {
+        assert!(RateLimiter::new(MAX_TPS, 1, 1).is_ok());
+    }
+
+    #[test]
+    fn new_rejects_rate_above_supported_max() {
+        let err = RateLimiter::new(MAX_TPS + 1, 1, 1)
+            .err()
+            .expect("oversized rate must be rejected");
+        assert!(err
+            .to_string()
+            .contains("exceeds the maximum supported rate"));
     }
 }

--- a/crates/spammer/src/spammer.rs
+++ b/crates/spammer/src/spammer.rs
@@ -267,7 +267,7 @@ impl Spammer {
             config.max_rate,
             config.max_num_txs,
             config.num_generators,
-        ));
+        )?);
 
         // Create transaction generators and senders
         let (tx_generators, tx_senders, tx_ack_receivers) = if config.fire_and_forget {
@@ -689,7 +689,7 @@ impl Spammer {
             config.max_rate,
             config.max_num_txs,
             num_generators,
-        ));
+        )?);
 
         let mut tx_generators = Vec::new();
         let mut tx_senders = Vec::new();


### PR DESCRIPTION
## Summary

Fixes #349

Reject spammer rates above the highest distinct per-second rate supported by the `governor` limiter, and replace the limiter's integer-conversion panics with normal propagated errors.

The fix enforces the same upper bound at the CLI, configuration, and rate-limiter layers. It also covers both normal and resumed spammer construction paths.

---

## Problem

The spammer previously exposed `--rate` as an unbounded positive `u64`:

```rust
clap::value_parser!(u64).range(1..)
```

`Config::validate()` did not enforce an upper bound. The value eventually reached `RateLimiter::new()`, which narrowed it with:

```rust
u32::try_from(tps).expect("TPS must fit in u32")
```

A rate greater than `u32::MAX` therefore passed CLI and configuration validation, then panicked with:

```text
TPS must fit in u32: TryFromIntError(())
```

Implementation review also found that `u32::MAX` is not the true semantic limit. `governor` 0.8.1 computes its per-token interval as:

```text
1_000_000_000 nanoseconds / rate
```

Rates above `1_000_000_000` round this interval down to zero nanoseconds, after which the GCRA implementation clamps it to one nanosecond. Such values fit in `u32`, but cannot be represented as distinct requested rates.

The correct maximum for this path is therefore `1_000_000_000` TPS.

---

## Changes

- Define a single `MAX_TPS` value of `1_000_000_000` at the rate-limiter boundary.
- Limit the Clap `--rate` parser to `1..=MAX_TPS`.
- Make `Config::validate()` enforce the same maximum for non-CLI callers.
- Change `RateLimiter::new()` to return `Result<Self>` instead of panicking on invalid rate or burst values.
- Propagate rate-limiter construction errors through both:
  - normal `Spammer::new()` construction;
  - resumed `Spammer::new_resuming()` construction.
- Add boundary and regression tests at the CLI, configuration, and limiter layers.

---

## Regression Coverage

The new tests verify that:

- `1_000_000_000` is accepted by the CLI;
- `1_000_000_001` is rejected by the CLI;
- `Config::validate()` accepts the supported maximum;
- `Config::validate()` rejects the first unsupported value;
- `RateLimiter::new()` accepts the supported maximum;
- `RateLimiter::new()` returns an error for the first unsupported value instead of panicking.

The rate limiter is fallible independently of CLI/config validation, preventing unvalidated library callers from reaching the old panic path.

---

## RED Verification

Before the fix, focused tests against current `main` demonstrated all three layers of the bug:

```text
CLI:
--rate accepted a value the rate limiter cannot represent

Config:
rate limiter only supports rates through u32::MAX

RateLimiter:
TPS must fit in u32: TryFromIntError(())
```

The CLI, configuration, and limiter regression tests all failed on the previous implementation.

A separate boundary probe confirmed that `u32::MAX` did not panic during construction; review of `governor`'s interval calculation then identified `1_000_000_000` as the actual distinct-rate limit.

---

## How to Test

Focused rejection tests:

```bash
cargo +1.94.0 test -p spammer supported_max -- --nocapture
```

Result:

```text
CLI/config/limiter rejection tests: 3 passed; 0 failed
```

Supported-boundary tests:

```bash
cargo +1.94.0 test -p spammer max_supported_rate -- --nocapture
```

Result:

```text
configuration/limiter maximum tests: 2 passed; 0 failed
```

Complete package:

```bash
cargo +1.94.0 test -p spammer
```

Results:

```text
library tests: 76 passed; 0 failed
binary tests: 11 passed; 0 failed
doc tests: 0 failed
```

Additional checks:

```bash
cargo +1.94.0 clippy -p spammer --all-targets -- -D warnings
cargo +1.94.0 fmt -p spammer -- --check
git diff --check
```

All checks passed.

The built CLI was also invoked with both `1_000_000_001` and `4_294_967_296`. Both values now produce a normal Clap validation error with exit code 2. Neither invocation emits panic text or reaches network initialization.

Local verification used Rust 1.94.0 because the local pinned 1.93.0 installation has a `cargo-clippy` component conflict. CI should provide the authoritative pinned-toolchain result.

---

## Scope and Risk

The change is limited to spammer rate validation and construction:

```text
crates/spammer/src/cli.rs
crates/spammer/src/config.rs
crates/spammer/src/main.rs
crates/spammer/src/rate_limiter.rs
crates/spammer/src/spammer.rs
```

It does not change:

- behavior for rates from 1 through `1_000_000_000`;
- transaction generation or sending;
- WebSocket behavior;
- account or nonce handling;
- consensus or protocol behavior;
- dependency versions.

Rates above `1_000_000_000` were previously accepted, but `governor` could not represent them as distinct rates because of nanosecond resolution. They are now rejected explicitly instead of being rounded or eventually panicking.

---

## Duplicate Check

Open and closed issues and pull requests were searched using the issue number, panic text, rate-limiter symbols, type boundary, and supported-rate wording. No duplicate PR or existing implementation was found.

---

## Checklist

- [x] Bug reproduced on current `main`
- [x] Regression tests confirmed failing before the fix
- [x] Actual limiter resolution boundary verified from `governor` 0.8.1 source
- [x] CLI and internal configuration enforce the same bound
- [x] Rate limiter no longer panics on invalid rates
- [x] Normal and resume paths propagate construction errors
- [x] Focused and complete package tests pass
- [x] Formatting and Clippy checks pass
- [x] Real CLI error path verified
- [x] No unrelated files changed
- [x] Independent follow-up review approved the corrected boundary
- [x] Follows Conventional Commits

---

## Impact

Type: 🐛 Bug fix

Fixes: #349
