### PR TITLE
fix(genesis): align ProtocolConfig schema with runtime consensus/fee checks

### DIFF
--- a/scripts/genesis/ProtocolConfig.ts
+++ b/scripts/genesis/ProtocolConfig.ts
@@ -44,6 +44,11 @@ const PROTOCOL_CONFIG_CONTROLLER_STORAGE_LOCATION = 0x958f8fec699b51a1249f513ece
 const PAUSABLE_STORAGE_LOCATION = 0x0642d7922329a434cf4fd17a3c95eb692c24fd95f9f94d0b55420a5d895f4a00n
 
 const maxUint64 = 18446744073709551615n
+const maxUint16 = 65535n
+// Packed into one storage slot as 8×uint16. Runtime updateConsensusParams also
+// requires each timeout (except targetBlockTimeMs) to be > 0.
+const schemaConsensusTimeoutMs = schemaBigInt.min(1n).max(maxUint16)
+const schemaTargetBlockTimeMs = schemaBigInt.min(0n).max(maxUint16)
 
 export const schemaProtocolConfig = z
   .object({
@@ -75,14 +80,14 @@ export const schemaProtocolConfig = z
     }),
     consensusParams: z
       .object({
-        timeoutProposeMs: schemaBigInt,
-        timeoutProposeDeltaMs: schemaBigInt,
-        timeoutPrevoteMs: schemaBigInt,
-        timeoutPrevoteDeltaMs: schemaBigInt,
-        timeoutPrecommitMs: schemaBigInt,
-        timeoutPrecommitDeltaMs: schemaBigInt,
-        timeoutRebroadcastMs: schemaBigInt,
-        targetBlockTimeMs: schemaBigInt,
+        timeoutProposeMs: schemaConsensusTimeoutMs,
+        timeoutProposeDeltaMs: schemaConsensusTimeoutMs,
+        timeoutPrevoteMs: schemaConsensusTimeoutMs,
+        timeoutPrevoteDeltaMs: schemaConsensusTimeoutMs,
+        timeoutPrecommitMs: schemaConsensusTimeoutMs,
+        timeoutPrecommitDeltaMs: schemaConsensusTimeoutMs,
+        timeoutRebroadcastMs: schemaConsensusTimeoutMs,
+        targetBlockTimeMs: schemaTargetBlockTimeMs,
       })
       .optional(),
   })
@@ -93,6 +98,15 @@ export const schemaProtocolConfig = z
       { key: 'controller', value: data.controller },
       { key: 'pauser', value: data.pauser },
     ])
+
+    // Match updateFeeParams: minBaseFee must not exceed maxBaseFee.
+    if (data.feeParams.minBaseFee > data.feeParams.maxBaseFee) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['feeParams', 'minBaseFee'],
+        message: 'minBaseFee must be <= maxBaseFee',
+      })
+    }
   })
 
 export type ProtocolConfigConfig = z.infer<typeof schemaProtocolConfig>

--- a/tests/unit/protocol-config-genesis.test.ts
+++ b/tests/unit/protocol-config-genesis.test.ts
@@ -1,0 +1,109 @@
+// Copyright 2026 Circle Internet Group, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai'
+import { schemaProtocolConfig } from '../../scripts/genesis/ProtocolConfig'
+
+const proxyAdmin = '0x0000000000000000000000000000000000000001'
+const owner = '0x0000000000000000000000000000000000000002'
+const controller = '0x0000000000000000000000000000000000000003'
+const pauser = '0x0000000000000000000000000000000000000004'
+
+const validConsensusParams = {
+  timeoutProposeMs: 3000n,
+  timeoutProposeDeltaMs: 500n,
+  timeoutPrevoteMs: 1000n,
+  timeoutPrevoteDeltaMs: 500n,
+  timeoutPrecommitMs: 1000n,
+  timeoutPrecommitDeltaMs: 500n,
+  timeoutRebroadcastMs: 2000n,
+  targetBlockTimeMs: 1000n,
+}
+
+const baseConfig = {
+  proxy: {
+    admin: proxyAdmin,
+  },
+  owner,
+  controller,
+  pauser,
+  feeParams: {
+    alpha: 1n,
+    kRate: 1n,
+    inverseElasticityMultiplier: 1n,
+    minBaseFee: 0n,
+    maxBaseFee: 1_000_000n,
+    blockGasLimit: 30_000_000n,
+  },
+  consensusParams: validConsensusParams,
+}
+
+describe('ProtocolConfig genesis schema', () => {
+  it('accepts a valid config', () => {
+    expect(() => schemaProtocolConfig.parse(baseConfig)).to.not.throw()
+  })
+
+  it('rejects zero consensus timeouts that updateConsensusParams also rejects', () => {
+    const timeoutKeys = [
+      'timeoutProposeMs',
+      'timeoutProposeDeltaMs',
+      'timeoutPrevoteMs',
+      'timeoutPrevoteDeltaMs',
+      'timeoutPrecommitMs',
+      'timeoutPrecommitDeltaMs',
+      'timeoutRebroadcastMs',
+    ] as const
+
+    for (const key of timeoutKeys) {
+      expect(
+        () =>
+          schemaProtocolConfig.parse({
+            ...baseConfig,
+            consensusParams: {
+              ...validConsensusParams,
+              [key]: 0n,
+            },
+          }),
+        `${key} should reject 0`,
+      ).to.throw()
+    }
+  })
+
+  it('rejects consensus params above uint16 max to prevent packed-slot overflow', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...baseConfig,
+        consensusParams: {
+          ...validConsensusParams,
+          timeoutProposeMs: 65536n,
+        },
+      }),
+    ).to.throw()
+  })
+
+  it('rejects minBaseFee greater than maxBaseFee', () => {
+    expect(() =>
+      schemaProtocolConfig.parse({
+        ...baseConfig,
+        feeParams: {
+          ...baseConfig.feeParams,
+          minBaseFee: 1000n,
+          maxBaseFee: 1n,
+        },
+      }),
+    ).to.throw()
+  })
+})


### PR DESCRIPTION
## Summary
Follow-up to the genesis/runtime invariant gaps discussed on #321 (and related to #320):

1. **Consensus timeouts must be `> 0` and `<= uint16`** — they are packed as 8×`uint16` into one storage slot, and `updateConsensusParams` rejects zero timeouts. Unbounded genesis values could overflow neighboring packed lanes or boot a chain with a zero propose timeout.
2. **`minBaseFee <= maxBaseFee`** — matches `updateFeeParams` / `InvalidBaseFeeRange`.

`blockGasLimit > 0` is already covered by #321 / open PRs, so this change leaves that field alone.

## Test plan
- [x] Added `tests/unit/protocol-config-genesis.test.ts` covering zero timeouts, `65536` overflow, and inverted base-fee range
- [ ] `make test-unit` (or the repo's hardhat unit target) once CI/maintainers can run it

Related: #320, #321