### PR TITLE
fix(spammer): reject --mix weight totals that overflow u32

### DIFF
--- a/crates/spammer/src/config.rs
+++ b/crates/spammer/src/config.rs
@@ -251,8 +251,22 @@ impl TxTypeMix {
         ]
     }
 
+    /// Sum of mix weights, or `None` if the sum overflows `u32`.
+    pub fn checked_total_weight(&self) -> Option<u32> {
+        self.transfer
+            .checked_add(self.legacy)?
+            .checked_add(self.erc20)?
+            .checked_add(self.guzzler)
+    }
+
+    /// Sum of mix weights.
+    ///
+    /// Prefer [`Self::checked_total_weight`] when the mix may come from
+    /// untrusted input. This method panics on overflow; call it only after
+    /// validation (or for known-good test fixtures).
     pub fn total_weight(&self) -> u32 {
-        self.transfer + self.legacy + self.erc20 + self.guzzler
+        self.checked_total_weight()
+            .expect("TxTypeMix weight total overflows u32; validate --mix before use")
     }
 }
 
@@ -285,6 +299,13 @@ impl FromStr for TxTypeMix {
                     ))
                 }
             }
+        }
+
+        if out.checked_total_weight().is_none() {
+            return Err(
+                "--mix total weight overflows u32; reduce individual weights so their sum fits in u32"
+                    .to_string(),
+            );
         }
 
         Ok(out)
@@ -371,8 +392,14 @@ impl Config {
         if let Err(msg) = self.guzzler_fn_weights.validate_enabled_args() {
             eyre::bail!("{msg}");
         }
-        if self.tx_type_mix.total_weight() == 0 {
-            eyre::bail!("--mix total weight is 0; at least one tx type must have weight > 0");
+        match self.tx_type_mix.checked_total_weight() {
+            None => eyre::bail!(
+                "--mix total weight overflows u32; reduce individual weights so their sum fits in u32"
+            ),
+            Some(0) => {
+                eyre::bail!("--mix total weight is 0; at least one tx type must have weight > 0")
+            }
+            Some(_) => {}
         }
         if self.tx_type_mix.guzzler > 0 && self.guzzler_fn_weights.total_weight() == 0 {
             eyre::bail!(
@@ -499,6 +526,47 @@ mod tests {
     fn tx_type_mix_rejects_invalid_weight() {
         let err = TxTypeMix::from_str("transfer=abc").expect_err("non-numeric should fail");
         assert!(err.contains("Invalid weight"));
+    }
+
+    #[test]
+    fn tx_type_mix_accepts_ordinary_ratio() {
+        let mix = TxTypeMix::from_str("transfer=70,legacy=30").expect("should parse");
+        assert_eq!(mix.checked_total_weight(), Some(100));
+    }
+
+    #[test]
+    fn tx_type_mix_accepts_total_equal_to_u32_max() {
+        let mix = TxTypeMix::from_str("transfer=4294967295").expect("u32::MAX alone is valid");
+        assert_eq!(mix.checked_total_weight(), Some(u32::MAX));
+    }
+
+    #[test]
+    fn tx_type_mix_rejects_overflowing_total() {
+        let err = TxTypeMix::from_str("transfer=4294967295,legacy=1")
+            .expect_err("sum above u32::MAX should fail");
+        assert!(err.contains("overflows u32"));
+    }
+
+    #[test]
+    fn tx_type_mix_rejects_overflow_across_later_fields() {
+        let err = TxTypeMix::from_str("transfer=2000000000,legacy=2000000000,erc20=294967296")
+            .expect_err("multi-field overflow should fail");
+        assert!(err.contains("overflows u32"));
+    }
+
+    #[test]
+    fn config_rejects_programmatic_overflowing_mix_without_panic() {
+        let config = Config {
+            tx_type_mix: TxTypeMix {
+                transfer: u32::MAX,
+                legacy: 1,
+                erc20: 0,
+                guzzler: 0,
+            },
+            ..default_config()
+        };
+        let err = config.validate().expect_err("overflowing mix must error");
+        assert!(err.to_string().contains("overflows u32"));
     }
 
     #[test]

--- a/crates/spammer/src/generator.rs
+++ b/crates/spammer/src/generator.rs
@@ -237,7 +237,10 @@ impl TxGenerator {
     }
 
     fn select_tx_type(&self) -> Result<TxType> {
-        let total = self.tx_type_mix.total_weight();
+        let total = self
+            .tx_type_mix
+            .checked_total_weight()
+            .ok_or_else(|| eyre::eyre!("--mix total weight overflows u32"))?;
         if total == 0 {
             eyre::bail!("select_tx_type called with total weight 0");
         }


### PR DESCRIPTION
## Summary
Fixes #352.

`--mix transfer=4294967295,legacy=1` parses successfully today because each weight is a valid `u32`, then panics in `TxTypeMix::total_weight()` during `Config::validate()` (`attempt to add with overflow`, exit 101).

## Changes
- Add `TxTypeMix::checked_total_weight()` using `checked_add`.
- Reject overflowing aggregates in `FromStr` and `Config::validate()` with a clear `--mix` error.
- Make `select_tx_type` consume the checked total so generation cannot rely on overflowing arithmetic.
- Add regression tests for ordinary ratios, `u32::MAX`, multi-field overflow, and programmatic `Config::validate()` (error, not panic).

## Test plan
- [x] `cargo test -p spammer tx_type_mix_` (and related config overflow test)