### PR TITLE
ci: run Hardhat unit tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      # hardhat-foundry invokes forge while loading the Hardhat config, even with --no-compile.
       - name: Read Foundry version
         id: foundry-version
         run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,37 @@ jobs:
           archive: false
 
   # ---------------------------------------------------------------------------
+  # TypeScript unit tests (standalone, no contract compile/submodules needed)
+  # ---------------------------------------------------------------------------
+
+  ts-unit-test:
+    name: TypeScript Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Read Foundry version
+        id: foundry-version
+        run: echo "version=$(cat .foundry-version)" >> $GITHUB_OUTPUT
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ steps.foundry-version.outputs.version }}
+
+      - name: Run hardhat unit tests
+        run: make test-unit-hardhat
+
+  # ---------------------------------------------------------------------------
   # Solidity Contracts: lint (fast) -> build -> test
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Summary
add a dedicated TypeScript Unit Tests CI job
install Node 22 and the repo-pinned Foundry version
run the existing make test-unit-hardhat target
intentionally skip contract submodule initialization and compilation because this unit suite does not require them
This ensures the existing Hardhat unit suite is exercised on pull requests instead of remaining outside CI.
Fixes #369