### PR TITLE
docs: document eth_getLogs query limits

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -96,6 +96,14 @@ For a complete list of available flags, see the [Reth CLI reference](https://ret
 arc-node-execution node --help
 ```
 
+Two inherited Reth flags control the size of `eth_getLogs` queries:
+
+- `--rpc.max-blocks-per-filter <N>` limits the block range scanned by one filter (default: `100000`).
+- `--rpc.max-logs-per-response <N>` limits the number of logs returned by one response (default: `20000`).
+
+These limits apply to a node's own RPC server. A public gateway or reverse proxy
+may enforce stricter limits independently.
+
 #### Custom flags
 
 In addition to standard Reth flags, `arc-node-execution` provides the following custom flags:

--- a/docs/running-an-arc-node.md
+++ b/docs/running-an-arc-node.md
@@ -196,6 +196,12 @@ and `--rpc.max-subscriptions-per-connection` (default `32`) if clients see
 `MaxConnections` or `TooManySubscriptions` errors. The defaults bound WebSocket
 log-fanout memory growth and should only be raised, not lowered.
 
+For `eth_getLogs`, `--rpc.max-blocks-per-filter` limits the block range scanned
+by one filter (default `100000`), while `--rpc.max-logs-per-response` limits the
+number of logs returned by one response (default `20000`). These inherited Reth
+limits apply to the node itself; a public gateway or reverse proxy may enforce
+stricter limits independently.
+
 ### Start consensus layer
 
 After starting the [execution layer](#start-execution-layer), in a different terminal, start the consensus layer:


### PR DESCRIPTION
## Summary

- document the inherited `--rpc.max-blocks-per-filter` and `--rpc.max-logs-per-response` flags
- record their Reth defaults of `100000` blocks and `20000` logs
- clarify that public gateways and reverse proxies may enforce stricter limits independently

This captures the repo-owned documentation follow-up identified in #83 without changing node behavior or duplicating the pending-tag fix in #340.

## Validation

- `git diff --check`

Related to #83.